### PR TITLE
BUILD-1340: Update rpms.lock.yaml with UBI Minimal update

### DIFF
--- a/.konflux/controller/Dockerfile
+++ b/.konflux/controller/Dockerfile
@@ -6,7 +6,7 @@ COPY build .
 
 RUN CGO_ENABLED=1 GO111MODULE=on go build -a -mod=vendor -ldflags="-s -w" -tags="strictfipsruntime" -o openshift-builds-controller ./cmd/shipwright-build-controller
 
-FROM registry.access.redhat.com/ubi9-minimal@sha256:b87097994ed62fbf1de70bc75debe8dacf3ea6e00dd577d74503ef66452c59d6
+FROM registry.access.redhat.com/ubi9-minimal@sha256:14f14e03d68f7fd5f2b18a13478b6b127c341b346c86b6e0b886ed2b7573b8e0
 
 COPY --from=builder /opt/app-root/src/openshift-builds-controller .
 COPY LICENSE /licenses/

--- a/.konflux/git-cloner/Dockerfile
+++ b/.konflux/git-cloner/Dockerfile
@@ -6,7 +6,7 @@ COPY build .
 
 RUN CGO_ENABLED=1 GO111MODULE=on go build -a -mod=vendor -ldflags="-s -w" -tags="strictfipsruntime" -o openshift-builds-git-cloner ./cmd/git
 
-FROM registry.access.redhat.com/ubi9-minimal@sha256:b87097994ed62fbf1de70bc75debe8dacf3ea6e00dd577d74503ef66452c59d6
+FROM registry.access.redhat.com/ubi9-minimal@sha256:14f14e03d68f7fd5f2b18a13478b6b127c341b346c86b6e0b886ed2b7573b8e0
 
 RUN \
   microdnf --assumeyes --nodocs install git git-lfs && \

--- a/.konflux/git-cloner/rpms.lock.yaml
+++ b/.konflux/git-cloner/rpms.lock.yaml
@@ -4,41 +4,41 @@ lockfileVendor: redhat
 arches:
 - arch: aarch64
   packages:
-  - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/aarch64/appstream/os/Packages/e/emacs-filesystem-27.2-10.el9_4.noarch.rpm
+  - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/aarch64/appstream/os/Packages/e/emacs-filesystem-27.2-11.el9_5.1.noarch.rpm
     repoid: ubi-9-appstream-rpms
-    size: 9490
-    checksum: sha256:e04cd595ed5641c8622ff123a8bc5df9ccfecd5f53204c3944f9e9a31e60e2cf
+    size: 9756
+    checksum: sha256:0c0a41c8f61f7509326ccba340211fcd5638397df397d942fb486f1c37966d13
     name: emacs-filesystem
-    evr: 1:27.2-10.el9_4
-    sourcerpm: emacs-27.2-10.el9_4.src.rpm
-  - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/aarch64/appstream/os/Packages/g/git-2.43.5-1.el9_4.aarch64.rpm
+    evr: 1:27.2-11.el9_5.1
+    sourcerpm: emacs-27.2-11.el9_5.1.src.rpm
+  - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/aarch64/appstream/os/Packages/g/git-2.43.5-2.el9_5.aarch64.rpm
     repoid: ubi-9-appstream-rpms
-    size: 55729
-    checksum: sha256:b05f60f73ab52f36a29c852af9227cffa491e0bcce84b182f3022de4f8c5eef8
+    size: 55786
+    checksum: sha256:215139968f00f55de62168ac7da99ed5baf3a7268f6bfbacaad7132706cda7d6
     name: git
-    evr: 2.43.5-1.el9_4
-    sourcerpm: git-2.43.5-1.el9_4.src.rpm
-  - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/aarch64/appstream/os/Packages/g/git-core-2.43.5-1.el9_4.aarch64.rpm
+    evr: 2.43.5-2.el9_5
+    sourcerpm: git-2.43.5-2.el9_5.src.rpm
+  - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/aarch64/appstream/os/Packages/g/git-core-2.43.5-2.el9_5.aarch64.rpm
     repoid: ubi-9-appstream-rpms
-    size: 4738888
-    checksum: sha256:1d9f1dbd09aeb6032082edb07d8429d7f1476ade1fa484ac6c135b516b3a6ed8
+    size: 4738228
+    checksum: sha256:490fdeafbf2f6ed88fd567c473cb28d00d69b55e42ee483f4b24258c0794fd5b
     name: git-core
-    evr: 2.43.5-1.el9_4
-    sourcerpm: git-2.43.5-1.el9_4.src.rpm
-  - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/aarch64/appstream/os/Packages/g/git-core-doc-2.43.5-1.el9_4.noarch.rpm
+    evr: 2.43.5-2.el9_5
+    sourcerpm: git-2.43.5-2.el9_5.src.rpm
+  - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/aarch64/appstream/os/Packages/g/git-core-doc-2.43.5-2.el9_5.noarch.rpm
     repoid: ubi-9-appstream-rpms
-    size: 3079814
-    checksum: sha256:157a6543062624ee7903639af57c089347adb36d69671e84f3e5ca7e44712ce7
+    size: 3079904
+    checksum: sha256:db2fd25ee56c274d0cdad6baca774e7ac4cadf144604e818ab6c87584d597ffb
     name: git-core-doc
-    evr: 2.43.5-1.el9_4
-    sourcerpm: git-2.43.5-1.el9_4.src.rpm
-  - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/aarch64/appstream/os/Packages/g/git-lfs-3.4.1-4.el9_4.aarch64.rpm
+    evr: 2.43.5-2.el9_5
+    sourcerpm: git-2.43.5-2.el9_5.src.rpm
+  - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/aarch64/appstream/os/Packages/g/git-lfs-3.4.1-4.el9_5.aarch64.rpm
     repoid: ubi-9-appstream-rpms
-    size: 4024443
-    checksum: sha256:304a82726db8adc66f785d427b6e3492a4b3e597bb005370a7aa2dcc84027794
+    size: 4105189
+    checksum: sha256:2e920997a465cd029a658da8b8cdd23fcdb32d700148a9c76fac64fd2f1af375
     name: git-lfs
-    evr: 3.4.1-4.el9_4
-    sourcerpm: git-lfs-3.4.1-4.el9_4.src.rpm
+    evr: 3.4.1-4.el9_5
+    sourcerpm: git-lfs-3.4.1-4.el9_5.src.rpm
   - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/aarch64/appstream/os/Packages/p/perl-AutoLoader-5.74-481.el9.noarch.rpm
     repoid: ubi-9-appstream-rpms
     size: 21821
@@ -186,13 +186,13 @@ arches:
     name: perl-Getopt-Std
     evr: 1.12-481.el9
     sourcerpm: perl-5.32.1-481.el9.src.rpm
-  - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/aarch64/appstream/os/Packages/p/perl-Git-2.43.5-1.el9_4.noarch.rpm
+  - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/aarch64/appstream/os/Packages/p/perl-Git-2.43.5-2.el9_5.noarch.rpm
     repoid: ubi-9-appstream-rpms
-    size: 40364
-    checksum: sha256:3a9c3a9d012f29ef3f815d0ba0f92284350a370e1893ae1c9b83a0422d13068e
+    size: 40421
+    checksum: sha256:fbbbc3d118ac4fd256e35369696fca5e8bff18a7c6cdcf8c2a8e1b5042047ef1
     name: perl-Git
-    evr: 2.43.5-1.el9_4
-    sourcerpm: git-2.43.5-1.el9_4.src.rpm
+    evr: 2.43.5-2.el9_5
+    sourcerpm: git-2.43.5-2.el9_5.src.rpm
   - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/aarch64/appstream/os/Packages/p/perl-HTTP-Tiny-0.076-462.el9.noarch.rpm
     repoid: ubi-9-appstream-rpms
     size: 58720
@@ -599,20 +599,20 @@ arches:
     name: openssh-clients
     evr: 8.7p1-43.el9
     sourcerpm: openssh-8.7p1-43.el9.src.rpm
-  - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/aarch64/baseos/os/Packages/o/openssl-3.2.2-6.el9_5.aarch64.rpm
+  - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/aarch64/baseos/os/Packages/o/openssl-3.2.2-6.el9_5.1.aarch64.rpm
     repoid: ubi-9-baseos-rpms
-    size: 1400933
-    checksum: sha256:c49a72d3ec0bf190d120d64ff9561dd6aa9a7928f0ffcd726daa626974e69902
+    size: 1398689
+    checksum: sha256:f914250a9ef52968e27af0f0e2520745df4443dc354367bec54dd06b4a2da60b
     name: openssl
-    evr: 1:3.2.2-6.el9_5
-    sourcerpm: openssl-3.2.2-6.el9_5.src.rpm
-  - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/aarch64/baseos/os/Packages/p/pam-1.5.1-20.el9.aarch64.rpm
+    evr: 1:3.2.2-6.el9_5.1
+    sourcerpm: openssl-3.2.2-6.el9_5.1.src.rpm
+  - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/aarch64/baseos/os/Packages/p/pam-1.5.1-22.el9_5.aarch64.rpm
     repoid: ubi-9-baseos-rpms
-    size: 646829
-    checksum: sha256:7a3c945abe46218be6f04e63296edc9935b0305ddc801f00ee3e0524ac0da0bc
+    size: 645036
+    checksum: sha256:e3a5a1eeed55a2ed968ba5435c0c172a102b7a37302f96770bb3f4dbb444effd
     name: pam
-    evr: 1.5.1-20.el9
-    sourcerpm: pam-1.5.1-20.el9.src.rpm
+    evr: 1.5.1-22.el9_5
+    sourcerpm: pam-1.5.1-22.el9_5.src.rpm
   - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/aarch64/baseos/os/Packages/u/util-linux-2.37.4-20.el9.aarch64.rpm
     repoid: ubi-9-baseos-rpms
     size: 2391631
@@ -628,24 +628,24 @@ arches:
     evr: 2.37.4-20.el9
     sourcerpm: util-linux-2.37.4-20.el9.src.rpm
   source:
-  - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/aarch64/appstream/source/SRPMS/Packages/e/emacs-27.2-10.el9_4.src.rpm
+  - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/aarch64/appstream/source/SRPMS/Packages/e/emacs-27.2-11.el9_5.1.src.rpm
     repoid: ubi-9-appstream-source
-    size: 44818364
-    checksum: sha256:310ce0bd588fcd7a502e4eb23f41138a62564a0954af82f3c9c0fd1084c63bfb
+    size: 44822831
+    checksum: sha256:38c5fde02ec16d0b2a9a2a85637e591e9776726e71dcf2b2913a5260855e01b9
     name: emacs
-    evr: 1:27.2-10.el9_4
-  - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/aarch64/appstream/source/SRPMS/Packages/g/git-2.43.5-1.el9_4.src.rpm
+    evr: 1:27.2-11.el9_5.1
+  - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/aarch64/appstream/source/SRPMS/Packages/g/git-2.43.5-2.el9_5.src.rpm
     repoid: ubi-9-appstream-source
-    size: 7444986
-    checksum: sha256:ca1d24f27e78e423b507052cdffff2fc1a182a74bb5a6876a9f3bed1b2078852
+    size: 7447825
+    checksum: sha256:8a13e0b20c35dc7b091d7659f5dd49cbc3dbb442da1f5096bc100e8fc1cd269f
     name: git
-    evr: 2.43.5-1.el9_4
-  - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/aarch64/appstream/source/SRPMS/Packages/g/git-lfs-3.4.1-4.el9_4.src.rpm
+    evr: 2.43.5-2.el9_5
+  - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/aarch64/appstream/source/SRPMS/Packages/g/git-lfs-3.4.1-4.el9_5.src.rpm
     repoid: ubi-9-appstream-source
-    size: 3497003
-    checksum: sha256:c8c011992eb4a6ee9b5b092bfde434c6ca20816c944c32766e30f92d8a8fb2ad
+    size: 3500817
+    checksum: sha256:1ae68536ad47e8da68516935177b71403a9953538e9376c3797b064edcef772e
     name: git-lfs
-    evr: 3.4.1-4.el9_4
+    evr: 3.4.1-4.el9_5
   - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/aarch64/appstream/source/SRPMS/Packages/p/perl-5.32.1-481.el9.src.rpm
     repoid: ubi-9-appstream-source
     size: 12784744
@@ -946,18 +946,18 @@ arches:
     checksum: sha256:27fe41a1d639254d73baea0f65bfd90321b1483e4e1ccad5e23db971fbc9db1d
     name: openssh
     evr: 8.7p1-43.el9
-  - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/aarch64/baseos/source/SRPMS/Packages/o/openssl-3.2.2-6.el9_5.src.rpm
+  - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/aarch64/baseos/source/SRPMS/Packages/o/openssl-3.2.2-6.el9_5.1.src.rpm
     repoid: ubi-9-baseos-source
-    size: 17984798
-    checksum: sha256:b58aa63f681560c0c4716ef22de299dcfd3219fd4de4b9f0d363648c59b92f37
+    size: 17985138
+    checksum: sha256:56c0b951be3e5ad6a1da594f9d4f09b8b752e2fb3d6827bcc03892f22f622b22
     name: openssl
-    evr: 1:3.2.2-6.el9_5
-  - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/aarch64/baseos/source/SRPMS/Packages/p/pam-1.5.1-20.el9.src.rpm
+    evr: 1:3.2.2-6.el9_5.1
+  - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/aarch64/baseos/source/SRPMS/Packages/p/pam-1.5.1-22.el9_5.src.rpm
     repoid: ubi-9-baseos-source
-    size: 1107946
-    checksum: sha256:a5edf4974b4ed014068713bc15e657408b622013e2e36ecca2ad1bfb791f67d7
+    size: 1112974
+    checksum: sha256:8224a77bca54712e2cef82141303493602f0403dbcfa8a713b3d48f533d17ff2
     name: pam
-    evr: 1.5.1-20.el9
+    evr: 1.5.1-22.el9_5
   - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/aarch64/baseos/source/SRPMS/Packages/u/util-linux-2.37.4-20.el9.src.rpm
     repoid: ubi-9-baseos-source
     size: 6278844
@@ -967,41 +967,41 @@ arches:
   module_metadata: []
 - arch: ppc64le
   packages:
-  - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/ppc64le/appstream/os/Packages/e/emacs-filesystem-27.2-10.el9_4.noarch.rpm
+  - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/ppc64le/appstream/os/Packages/e/emacs-filesystem-27.2-11.el9_5.1.noarch.rpm
     repoid: ubi-9-appstream-rpms
-    size: 9490
-    checksum: sha256:e04cd595ed5641c8622ff123a8bc5df9ccfecd5f53204c3944f9e9a31e60e2cf
+    size: 9756
+    checksum: sha256:0c0a41c8f61f7509326ccba340211fcd5638397df397d942fb486f1c37966d13
     name: emacs-filesystem
-    evr: 1:27.2-10.el9_4
-    sourcerpm: emacs-27.2-10.el9_4.src.rpm
-  - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/ppc64le/appstream/os/Packages/g/git-2.43.5-1.el9_4.ppc64le.rpm
+    evr: 1:27.2-11.el9_5.1
+    sourcerpm: emacs-27.2-11.el9_5.1.src.rpm
+  - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/ppc64le/appstream/os/Packages/g/git-2.43.5-2.el9_5.ppc64le.rpm
     repoid: ubi-9-appstream-rpms
-    size: 55741
-    checksum: sha256:387b77f5965dda1f05df67fc0c90daa9b2c841dbb56e7ab245f7c79b90090f15
+    size: 55804
+    checksum: sha256:617313133a60564f541a0322b9ffa2ed1c9e57bfe814a0c77ef3b54cc98bb747
     name: git
-    evr: 2.43.5-1.el9_4
-    sourcerpm: git-2.43.5-1.el9_4.src.rpm
-  - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/ppc64le/appstream/os/Packages/g/git-core-2.43.5-1.el9_4.ppc64le.rpm
+    evr: 2.43.5-2.el9_5
+    sourcerpm: git-2.43.5-2.el9_5.src.rpm
+  - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/ppc64le/appstream/os/Packages/g/git-core-2.43.5-2.el9_5.ppc64le.rpm
     repoid: ubi-9-appstream-rpms
-    size: 5085315
-    checksum: sha256:ca54d61fed798231dac7e5fd619022b0f9010315a9ab3ba3a0fc3e134702d577
+    size: 5085479
+    checksum: sha256:2c59c4c6b36e6571ee3ea56b364d4debd81d87436a7d65e7308d8a689ee6dd08
     name: git-core
-    evr: 2.43.5-1.el9_4
-    sourcerpm: git-2.43.5-1.el9_4.src.rpm
-  - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/ppc64le/appstream/os/Packages/g/git-core-doc-2.43.5-1.el9_4.noarch.rpm
+    evr: 2.43.5-2.el9_5
+    sourcerpm: git-2.43.5-2.el9_5.src.rpm
+  - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/ppc64le/appstream/os/Packages/g/git-core-doc-2.43.5-2.el9_5.noarch.rpm
     repoid: ubi-9-appstream-rpms
-    size: 3079814
-    checksum: sha256:157a6543062624ee7903639af57c089347adb36d69671e84f3e5ca7e44712ce7
+    size: 3079904
+    checksum: sha256:db2fd25ee56c274d0cdad6baca774e7ac4cadf144604e818ab6c87584d597ffb
     name: git-core-doc
-    evr: 2.43.5-1.el9_4
-    sourcerpm: git-2.43.5-1.el9_4.src.rpm
-  - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/ppc64le/appstream/os/Packages/g/git-lfs-3.4.1-4.el9_4.ppc64le.rpm
+    evr: 2.43.5-2.el9_5
+    sourcerpm: git-2.43.5-2.el9_5.src.rpm
+  - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/ppc64le/appstream/os/Packages/g/git-lfs-3.4.1-4.el9_5.ppc64le.rpm
     repoid: ubi-9-appstream-rpms
-    size: 4023591
-    checksum: sha256:8f588e46d6fe6f22a4c644fc10ba88fd1196f2556906c9e8b259b7c0be7f7cdb
+    size: 4108278
+    checksum: sha256:75ba2922fb0c3c21ce3b36cbcfb0dc7d4ae6e143385a6794b0bee0cab4f8b5cb
     name: git-lfs
-    evr: 3.4.1-4.el9_4
-    sourcerpm: git-lfs-3.4.1-4.el9_4.src.rpm
+    evr: 3.4.1-4.el9_5
+    sourcerpm: git-lfs-3.4.1-4.el9_5.src.rpm
   - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/ppc64le/appstream/os/Packages/p/perl-AutoLoader-5.74-481.el9.noarch.rpm
     repoid: ubi-9-appstream-rpms
     size: 21821
@@ -1149,13 +1149,13 @@ arches:
     name: perl-Getopt-Std
     evr: 1.12-481.el9
     sourcerpm: perl-5.32.1-481.el9.src.rpm
-  - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/ppc64le/appstream/os/Packages/p/perl-Git-2.43.5-1.el9_4.noarch.rpm
+  - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/ppc64le/appstream/os/Packages/p/perl-Git-2.43.5-2.el9_5.noarch.rpm
     repoid: ubi-9-appstream-rpms
-    size: 40364
-    checksum: sha256:3a9c3a9d012f29ef3f815d0ba0f92284350a370e1893ae1c9b83a0422d13068e
+    size: 40421
+    checksum: sha256:fbbbc3d118ac4fd256e35369696fca5e8bff18a7c6cdcf8c2a8e1b5042047ef1
     name: perl-Git
-    evr: 2.43.5-1.el9_4
-    sourcerpm: git-2.43.5-1.el9_4.src.rpm
+    evr: 2.43.5-2.el9_5
+    sourcerpm: git-2.43.5-2.el9_5.src.rpm
   - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/ppc64le/appstream/os/Packages/p/perl-HTTP-Tiny-0.076-462.el9.noarch.rpm
     repoid: ubi-9-appstream-rpms
     size: 58720
@@ -1569,20 +1569,20 @@ arches:
     name: openssh-clients
     evr: 8.7p1-43.el9
     sourcerpm: openssh-8.7p1-43.el9.src.rpm
-  - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/ppc64le/baseos/os/Packages/o/openssl-3.2.2-6.el9_5.ppc64le.rpm
+  - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/ppc64le/baseos/os/Packages/o/openssl-3.2.2-6.el9_5.1.ppc64le.rpm
     repoid: ubi-9-baseos-rpms
-    size: 1425529
-    checksum: sha256:4f89f5cf48a836392a03f8e037cdcb55b2d2b4ab05b8bba821a11cbc3e9a355d
+    size: 1422952
+    checksum: sha256:56283cbf84234ec9256fb68e2d2669bc5799862eb2ee40521b8ac59044567835
     name: openssl
-    evr: 1:3.2.2-6.el9_5
-    sourcerpm: openssl-3.2.2-6.el9_5.src.rpm
-  - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/ppc64le/baseos/os/Packages/p/pam-1.5.1-20.el9.ppc64le.rpm
+    evr: 1:3.2.2-6.el9_5.1
+    sourcerpm: openssl-3.2.2-6.el9_5.1.src.rpm
+  - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/ppc64le/baseos/os/Packages/p/pam-1.5.1-22.el9_5.ppc64le.rpm
     repoid: ubi-9-baseos-rpms
-    size: 687514
-    checksum: sha256:e679bea5c0f58825e961bf263510de35527f4681e59a98d0051b6098d6dcbc62
+    size: 687467
+    checksum: sha256:1ec4fbd11c964b8f8e389d015b380f7c61e54b9b317bba92efb1287c06163445
     name: pam
-    evr: 1.5.1-20.el9
-    sourcerpm: pam-1.5.1-20.el9.src.rpm
+    evr: 1.5.1-22.el9_5
+    sourcerpm: pam-1.5.1-22.el9_5.src.rpm
   - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/ppc64le/baseos/os/Packages/u/util-linux-2.37.4-20.el9.ppc64le.rpm
     repoid: ubi-9-baseos-rpms
     size: 2428616
@@ -1598,24 +1598,24 @@ arches:
     evr: 2.37.4-20.el9
     sourcerpm: util-linux-2.37.4-20.el9.src.rpm
   source:
-  - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/ppc64le/appstream/source/SRPMS/Packages/e/emacs-27.2-10.el9_4.src.rpm
+  - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/ppc64le/appstream/source/SRPMS/Packages/e/emacs-27.2-11.el9_5.1.src.rpm
     repoid: ubi-9-appstream-source
-    size: 44818364
-    checksum: sha256:310ce0bd588fcd7a502e4eb23f41138a62564a0954af82f3c9c0fd1084c63bfb
+    size: 44822831
+    checksum: sha256:38c5fde02ec16d0b2a9a2a85637e591e9776726e71dcf2b2913a5260855e01b9
     name: emacs
-    evr: 1:27.2-10.el9_4
-  - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/ppc64le/appstream/source/SRPMS/Packages/g/git-2.43.5-1.el9_4.src.rpm
+    evr: 1:27.2-11.el9_5.1
+  - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/ppc64le/appstream/source/SRPMS/Packages/g/git-2.43.5-2.el9_5.src.rpm
     repoid: ubi-9-appstream-source
-    size: 7444986
-    checksum: sha256:ca1d24f27e78e423b507052cdffff2fc1a182a74bb5a6876a9f3bed1b2078852
+    size: 7447825
+    checksum: sha256:8a13e0b20c35dc7b091d7659f5dd49cbc3dbb442da1f5096bc100e8fc1cd269f
     name: git
-    evr: 2.43.5-1.el9_4
-  - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/ppc64le/appstream/source/SRPMS/Packages/g/git-lfs-3.4.1-4.el9_4.src.rpm
+    evr: 2.43.5-2.el9_5
+  - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/ppc64le/appstream/source/SRPMS/Packages/g/git-lfs-3.4.1-4.el9_5.src.rpm
     repoid: ubi-9-appstream-source
-    size: 3497003
-    checksum: sha256:c8c011992eb4a6ee9b5b092bfde434c6ca20816c944c32766e30f92d8a8fb2ad
+    size: 3500817
+    checksum: sha256:1ae68536ad47e8da68516935177b71403a9953538e9376c3797b064edcef772e
     name: git-lfs
-    evr: 3.4.1-4.el9_4
+    evr: 3.4.1-4.el9_5
   - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/ppc64le/appstream/source/SRPMS/Packages/p/perl-5.32.1-481.el9.src.rpm
     repoid: ubi-9-appstream-source
     size: 12784744
@@ -1922,18 +1922,18 @@ arches:
     checksum: sha256:27fe41a1d639254d73baea0f65bfd90321b1483e4e1ccad5e23db971fbc9db1d
     name: openssh
     evr: 8.7p1-43.el9
-  - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/ppc64le/baseos/source/SRPMS/Packages/o/openssl-3.2.2-6.el9_5.src.rpm
+  - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/ppc64le/baseos/source/SRPMS/Packages/o/openssl-3.2.2-6.el9_5.1.src.rpm
     repoid: ubi-9-baseos-source
-    size: 17984798
-    checksum: sha256:b58aa63f681560c0c4716ef22de299dcfd3219fd4de4b9f0d363648c59b92f37
+    size: 17985138
+    checksum: sha256:56c0b951be3e5ad6a1da594f9d4f09b8b752e2fb3d6827bcc03892f22f622b22
     name: openssl
-    evr: 1:3.2.2-6.el9_5
-  - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/ppc64le/baseos/source/SRPMS/Packages/p/pam-1.5.1-20.el9.src.rpm
+    evr: 1:3.2.2-6.el9_5.1
+  - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/ppc64le/baseos/source/SRPMS/Packages/p/pam-1.5.1-22.el9_5.src.rpm
     repoid: ubi-9-baseos-source
-    size: 1107946
-    checksum: sha256:a5edf4974b4ed014068713bc15e657408b622013e2e36ecca2ad1bfb791f67d7
+    size: 1112974
+    checksum: sha256:8224a77bca54712e2cef82141303493602f0403dbcfa8a713b3d48f533d17ff2
     name: pam
-    evr: 1.5.1-20.el9
+    evr: 1.5.1-22.el9_5
   - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/ppc64le/baseos/source/SRPMS/Packages/u/util-linux-2.37.4-20.el9.src.rpm
     repoid: ubi-9-baseos-source
     size: 6278844
@@ -1943,41 +1943,41 @@ arches:
   module_metadata: []
 - arch: s390x
   packages:
-  - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/s390x/appstream/os/Packages/e/emacs-filesystem-27.2-10.el9_4.noarch.rpm
+  - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/s390x/appstream/os/Packages/e/emacs-filesystem-27.2-11.el9_5.1.noarch.rpm
     repoid: ubi-9-appstream-rpms
-    size: 9490
-    checksum: sha256:e04cd595ed5641c8622ff123a8bc5df9ccfecd5f53204c3944f9e9a31e60e2cf
+    size: 9756
+    checksum: sha256:0c0a41c8f61f7509326ccba340211fcd5638397df397d942fb486f1c37966d13
     name: emacs-filesystem
-    evr: 1:27.2-10.el9_4
-    sourcerpm: emacs-27.2-10.el9_4.src.rpm
-  - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/s390x/appstream/os/Packages/g/git-2.43.5-1.el9_4.s390x.rpm
+    evr: 1:27.2-11.el9_5.1
+    sourcerpm: emacs-27.2-11.el9_5.1.src.rpm
+  - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/s390x/appstream/os/Packages/g/git-2.43.5-2.el9_5.s390x.rpm
     repoid: ubi-9-appstream-rpms
-    size: 55743
-    checksum: sha256:eda9a93e7bf9a7c9bece3d6ab0504f6ae6be7fdd8d610e73ca98860c0738c173
+    size: 55793
+    checksum: sha256:90c8c39f142ca962607fe31c154548c8789314887ec70015e6b2e08ba0227d87
     name: git
-    evr: 2.43.5-1.el9_4
-    sourcerpm: git-2.43.5-1.el9_4.src.rpm
-  - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/s390x/appstream/os/Packages/g/git-core-2.43.5-1.el9_4.s390x.rpm
+    evr: 2.43.5-2.el9_5
+    sourcerpm: git-2.43.5-2.el9_5.src.rpm
+  - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/s390x/appstream/os/Packages/g/git-core-2.43.5-2.el9_5.s390x.rpm
     repoid: ubi-9-appstream-rpms
-    size: 4528669
-    checksum: sha256:25a6426e4a4e0915ae3bd43fb9c4d8f6e1de1ebc787d434457b88a162fcc85c1
+    size: 4527898
+    checksum: sha256:35f7fbdd7028e0d9085226ce632071fa61457fb13ff84db9b9f50abda9b70c02
     name: git-core
-    evr: 2.43.5-1.el9_4
-    sourcerpm: git-2.43.5-1.el9_4.src.rpm
-  - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/s390x/appstream/os/Packages/g/git-core-doc-2.43.5-1.el9_4.noarch.rpm
+    evr: 2.43.5-2.el9_5
+    sourcerpm: git-2.43.5-2.el9_5.src.rpm
+  - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/s390x/appstream/os/Packages/g/git-core-doc-2.43.5-2.el9_5.noarch.rpm
     repoid: ubi-9-appstream-rpms
-    size: 3079814
-    checksum: sha256:157a6543062624ee7903639af57c089347adb36d69671e84f3e5ca7e44712ce7
+    size: 3079904
+    checksum: sha256:db2fd25ee56c274d0cdad6baca774e7ac4cadf144604e818ab6c87584d597ffb
     name: git-core-doc
-    evr: 2.43.5-1.el9_4
-    sourcerpm: git-2.43.5-1.el9_4.src.rpm
-  - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/s390x/appstream/os/Packages/g/git-lfs-3.4.1-4.el9_4.s390x.rpm
+    evr: 2.43.5-2.el9_5
+    sourcerpm: git-2.43.5-2.el9_5.src.rpm
+  - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/s390x/appstream/os/Packages/g/git-lfs-3.4.1-4.el9_5.s390x.rpm
     repoid: ubi-9-appstream-rpms
-    size: 4161399
-    checksum: sha256:60b0c068f8c756fcaeba5e7ad75ea2c2e74219e71b2d2455f52264347b2ea2fc
+    size: 4229231
+    checksum: sha256:608424b53a261e427071a4bbb491a87b5faf0d44550bb2a22f388e6760040c83
     name: git-lfs
-    evr: 3.4.1-4.el9_4
-    sourcerpm: git-lfs-3.4.1-4.el9_4.src.rpm
+    evr: 3.4.1-4.el9_5
+    sourcerpm: git-lfs-3.4.1-4.el9_5.src.rpm
   - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/s390x/appstream/os/Packages/p/perl-AutoLoader-5.74-481.el9.noarch.rpm
     repoid: ubi-9-appstream-rpms
     size: 21821
@@ -2125,13 +2125,13 @@ arches:
     name: perl-Getopt-Std
     evr: 1.12-481.el9
     sourcerpm: perl-5.32.1-481.el9.src.rpm
-  - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/s390x/appstream/os/Packages/p/perl-Git-2.43.5-1.el9_4.noarch.rpm
+  - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/s390x/appstream/os/Packages/p/perl-Git-2.43.5-2.el9_5.noarch.rpm
     repoid: ubi-9-appstream-rpms
-    size: 40364
-    checksum: sha256:3a9c3a9d012f29ef3f815d0ba0f92284350a370e1893ae1c9b83a0422d13068e
+    size: 40421
+    checksum: sha256:fbbbc3d118ac4fd256e35369696fca5e8bff18a7c6cdcf8c2a8e1b5042047ef1
     name: perl-Git
-    evr: 2.43.5-1.el9_4
-    sourcerpm: git-2.43.5-1.el9_4.src.rpm
+    evr: 2.43.5-2.el9_5
+    sourcerpm: git-2.43.5-2.el9_5.src.rpm
   - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/s390x/appstream/os/Packages/p/perl-HTTP-Tiny-0.076-462.el9.noarch.rpm
     repoid: ubi-9-appstream-rpms
     size: 58720
@@ -2538,20 +2538,20 @@ arches:
     name: openssh-clients
     evr: 8.7p1-43.el9
     sourcerpm: openssh-8.7p1-43.el9.src.rpm
-  - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/s390x/baseos/os/Packages/o/openssl-3.2.2-6.el9_5.s390x.rpm
+  - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/s390x/baseos/os/Packages/o/openssl-3.2.2-6.el9_5.1.s390x.rpm
     repoid: ubi-9-baseos-rpms
-    size: 1411535
-    checksum: sha256:2beedaddbb49df52f48b181aa1515c59e600799f8784a691b098c43d77853376
+    size: 1407537
+    checksum: sha256:0a24289ee6324c2ecd6edad913f8ecfcfc6db43fbf6fed65458141e3ec0c104f
     name: openssl
-    evr: 1:3.2.2-6.el9_5
-    sourcerpm: openssl-3.2.2-6.el9_5.src.rpm
-  - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/s390x/baseos/os/Packages/p/pam-1.5.1-20.el9.s390x.rpm
+    evr: 1:3.2.2-6.el9_5.1
+    sourcerpm: openssl-3.2.2-6.el9_5.1.src.rpm
+  - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/s390x/baseos/os/Packages/p/pam-1.5.1-22.el9_5.s390x.rpm
     repoid: ubi-9-baseos-rpms
-    size: 641355
-    checksum: sha256:bdedb4d40965afe3622eeea7951bf1c4578ee12d0530569a68c1072ce6ce660d
+    size: 640693
+    checksum: sha256:61434186414151740d7e7cdf03421e40d3352885c34b9fee668574a3fb0bdfe7
     name: pam
-    evr: 1.5.1-20.el9
-    sourcerpm: pam-1.5.1-20.el9.src.rpm
+    evr: 1.5.1-22.el9_5
+    sourcerpm: pam-1.5.1-22.el9_5.src.rpm
   - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/s390x/baseos/os/Packages/u/util-linux-2.37.4-20.el9.s390x.rpm
     repoid: ubi-9-baseos-rpms
     size: 2336453
@@ -2567,24 +2567,24 @@ arches:
     evr: 2.37.4-20.el9
     sourcerpm: util-linux-2.37.4-20.el9.src.rpm
   source:
-  - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/s390x/appstream/source/SRPMS/Packages/e/emacs-27.2-10.el9_4.src.rpm
+  - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/s390x/appstream/source/SRPMS/Packages/e/emacs-27.2-11.el9_5.1.src.rpm
     repoid: ubi-9-appstream-source
-    size: 44818364
-    checksum: sha256:310ce0bd588fcd7a502e4eb23f41138a62564a0954af82f3c9c0fd1084c63bfb
+    size: 44822831
+    checksum: sha256:38c5fde02ec16d0b2a9a2a85637e591e9776726e71dcf2b2913a5260855e01b9
     name: emacs
-    evr: 1:27.2-10.el9_4
-  - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/s390x/appstream/source/SRPMS/Packages/g/git-2.43.5-1.el9_4.src.rpm
+    evr: 1:27.2-11.el9_5.1
+  - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/s390x/appstream/source/SRPMS/Packages/g/git-2.43.5-2.el9_5.src.rpm
     repoid: ubi-9-appstream-source
-    size: 7444986
-    checksum: sha256:ca1d24f27e78e423b507052cdffff2fc1a182a74bb5a6876a9f3bed1b2078852
+    size: 7447825
+    checksum: sha256:8a13e0b20c35dc7b091d7659f5dd49cbc3dbb442da1f5096bc100e8fc1cd269f
     name: git
-    evr: 2.43.5-1.el9_4
-  - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/s390x/appstream/source/SRPMS/Packages/g/git-lfs-3.4.1-4.el9_4.src.rpm
+    evr: 2.43.5-2.el9_5
+  - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/s390x/appstream/source/SRPMS/Packages/g/git-lfs-3.4.1-4.el9_5.src.rpm
     repoid: ubi-9-appstream-source
-    size: 3497003
-    checksum: sha256:c8c011992eb4a6ee9b5b092bfde434c6ca20816c944c32766e30f92d8a8fb2ad
+    size: 3500817
+    checksum: sha256:1ae68536ad47e8da68516935177b71403a9953538e9376c3797b064edcef772e
     name: git-lfs
-    evr: 3.4.1-4.el9_4
+    evr: 3.4.1-4.el9_5
   - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/s390x/appstream/source/SRPMS/Packages/p/perl-5.32.1-481.el9.src.rpm
     repoid: ubi-9-appstream-source
     size: 12784744
@@ -2885,18 +2885,18 @@ arches:
     checksum: sha256:27fe41a1d639254d73baea0f65bfd90321b1483e4e1ccad5e23db971fbc9db1d
     name: openssh
     evr: 8.7p1-43.el9
-  - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/s390x/baseos/source/SRPMS/Packages/o/openssl-3.2.2-6.el9_5.src.rpm
+  - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/s390x/baseos/source/SRPMS/Packages/o/openssl-3.2.2-6.el9_5.1.src.rpm
     repoid: ubi-9-baseos-source
-    size: 17984798
-    checksum: sha256:b58aa63f681560c0c4716ef22de299dcfd3219fd4de4b9f0d363648c59b92f37
+    size: 17985138
+    checksum: sha256:56c0b951be3e5ad6a1da594f9d4f09b8b752e2fb3d6827bcc03892f22f622b22
     name: openssl
-    evr: 1:3.2.2-6.el9_5
-  - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/s390x/baseos/source/SRPMS/Packages/p/pam-1.5.1-20.el9.src.rpm
+    evr: 1:3.2.2-6.el9_5.1
+  - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/s390x/baseos/source/SRPMS/Packages/p/pam-1.5.1-22.el9_5.src.rpm
     repoid: ubi-9-baseos-source
-    size: 1107946
-    checksum: sha256:a5edf4974b4ed014068713bc15e657408b622013e2e36ecca2ad1bfb791f67d7
+    size: 1112974
+    checksum: sha256:8224a77bca54712e2cef82141303493602f0403dbcfa8a713b3d48f533d17ff2
     name: pam
-    evr: 1.5.1-20.el9
+    evr: 1.5.1-22.el9_5
   - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/s390x/baseos/source/SRPMS/Packages/u/util-linux-2.37.4-20.el9.src.rpm
     repoid: ubi-9-baseos-source
     size: 6278844
@@ -2906,41 +2906,41 @@ arches:
   module_metadata: []
 - arch: x86_64
   packages:
-  - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/x86_64/appstream/os/Packages/e/emacs-filesystem-27.2-10.el9_4.noarch.rpm
+  - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/x86_64/appstream/os/Packages/e/emacs-filesystem-27.2-11.el9_5.1.noarch.rpm
     repoid: ubi-9-appstream-rpms
-    size: 9490
-    checksum: sha256:e04cd595ed5641c8622ff123a8bc5df9ccfecd5f53204c3944f9e9a31e60e2cf
+    size: 9756
+    checksum: sha256:0c0a41c8f61f7509326ccba340211fcd5638397df397d942fb486f1c37966d13
     name: emacs-filesystem
-    evr: 1:27.2-10.el9_4
-    sourcerpm: emacs-27.2-10.el9_4.src.rpm
-  - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/x86_64/appstream/os/Packages/g/git-2.43.5-1.el9_4.x86_64.rpm
+    evr: 1:27.2-11.el9_5.1
+    sourcerpm: emacs-27.2-11.el9_5.1.src.rpm
+  - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/x86_64/appstream/os/Packages/g/git-2.43.5-2.el9_5.x86_64.rpm
     repoid: ubi-9-appstream-rpms
-    size: 55762
-    checksum: sha256:0d28337e70e5a91eb1ac742eaa38c7e44e7d94fa284017efa65ea70151c2fd52
+    size: 55815
+    checksum: sha256:57523f07b585c3df994273049dab289e752e774ab8f1231b9919352becbf57d0
     name: git
-    evr: 2.43.5-1.el9_4
-    sourcerpm: git-2.43.5-1.el9_4.src.rpm
-  - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/x86_64/appstream/os/Packages/g/git-core-2.43.5-1.el9_4.x86_64.rpm
+    evr: 2.43.5-2.el9_5
+    sourcerpm: git-2.43.5-2.el9_5.src.rpm
+  - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/x86_64/appstream/os/Packages/g/git-core-2.43.5-2.el9_5.x86_64.rpm
     repoid: ubi-9-appstream-rpms
-    size: 4651148
-    checksum: sha256:5f59cef4ff08d8fe3a53064d417fab92ea9389fb9af19919755e8b4d12ee1373
+    size: 4651307
+    checksum: sha256:8416822a6000aedc9b3818dd7b297c68f741bd2569f46c888df72f3c5196238d
     name: git-core
-    evr: 2.43.5-1.el9_4
-    sourcerpm: git-2.43.5-1.el9_4.src.rpm
-  - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/x86_64/appstream/os/Packages/g/git-core-doc-2.43.5-1.el9_4.noarch.rpm
+    evr: 2.43.5-2.el9_5
+    sourcerpm: git-2.43.5-2.el9_5.src.rpm
+  - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/x86_64/appstream/os/Packages/g/git-core-doc-2.43.5-2.el9_5.noarch.rpm
     repoid: ubi-9-appstream-rpms
-    size: 3079814
-    checksum: sha256:157a6543062624ee7903639af57c089347adb36d69671e84f3e5ca7e44712ce7
+    size: 3079904
+    checksum: sha256:db2fd25ee56c274d0cdad6baca774e7ac4cadf144604e818ab6c87584d597ffb
     name: git-core-doc
-    evr: 2.43.5-1.el9_4
-    sourcerpm: git-2.43.5-1.el9_4.src.rpm
-  - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/x86_64/appstream/os/Packages/g/git-lfs-3.4.1-4.el9_4.x86_64.rpm
+    evr: 2.43.5-2.el9_5
+    sourcerpm: git-2.43.5-2.el9_5.src.rpm
+  - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/x86_64/appstream/os/Packages/g/git-lfs-3.4.1-4.el9_5.x86_64.rpm
     repoid: ubi-9-appstream-rpms
-    size: 4395395
-    checksum: sha256:e3bcdeb6a2d514fad41ac6c46250d549817155576d3d12b5ece37d08b45d98eb
+    size: 4510795
+    checksum: sha256:4d99b7f9565610f9a4bb4645f1a4aad5315312074f8d9cf6e2994e73eca6176e
     name: git-lfs
-    evr: 3.4.1-4.el9_4
-    sourcerpm: git-lfs-3.4.1-4.el9_4.src.rpm
+    evr: 3.4.1-4.el9_5
+    sourcerpm: git-lfs-3.4.1-4.el9_5.src.rpm
   - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/x86_64/appstream/os/Packages/p/perl-AutoLoader-5.74-481.el9.noarch.rpm
     repoid: ubi-9-appstream-rpms
     size: 21821
@@ -3088,13 +3088,13 @@ arches:
     name: perl-Getopt-Std
     evr: 1.12-481.el9
     sourcerpm: perl-5.32.1-481.el9.src.rpm
-  - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/x86_64/appstream/os/Packages/p/perl-Git-2.43.5-1.el9_4.noarch.rpm
+  - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/x86_64/appstream/os/Packages/p/perl-Git-2.43.5-2.el9_5.noarch.rpm
     repoid: ubi-9-appstream-rpms
-    size: 40364
-    checksum: sha256:3a9c3a9d012f29ef3f815d0ba0f92284350a370e1893ae1c9b83a0422d13068e
+    size: 40421
+    checksum: sha256:fbbbc3d118ac4fd256e35369696fca5e8bff18a7c6cdcf8c2a8e1b5042047ef1
     name: perl-Git
-    evr: 2.43.5-1.el9_4
-    sourcerpm: git-2.43.5-1.el9_4.src.rpm
+    evr: 2.43.5-2.el9_5
+    sourcerpm: git-2.43.5-2.el9_5.src.rpm
   - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/x86_64/appstream/os/Packages/p/perl-HTTP-Tiny-0.076-462.el9.noarch.rpm
     repoid: ubi-9-appstream-rpms
     size: 58720
@@ -3501,20 +3501,20 @@ arches:
     name: openssh-clients
     evr: 8.7p1-43.el9
     sourcerpm: openssh-8.7p1-43.el9.src.rpm
-  - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/x86_64/baseos/os/Packages/o/openssl-3.2.2-6.el9_5.x86_64.rpm
+  - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/x86_64/baseos/os/Packages/o/openssl-3.2.2-6.el9_5.1.x86_64.rpm
     repoid: ubi-9-baseos-rpms
-    size: 1423127
-    checksum: sha256:adea7d3b99a23d01925632de46597f90b9934f7f92b40c28f34ff5c501c6d8a6
+    size: 1420999
+    checksum: sha256:f379686df99db814e30568a896b417278775fc96864ac6d2660bf48ef94309e3
     name: openssl
-    evr: 1:3.2.2-6.el9_5
-    sourcerpm: openssl-3.2.2-6.el9_5.src.rpm
-  - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/x86_64/baseos/os/Packages/p/pam-1.5.1-20.el9.x86_64.rpm
+    evr: 1:3.2.2-6.el9_5.1
+    sourcerpm: openssl-3.2.2-6.el9_5.1.src.rpm
+  - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/x86_64/baseos/os/Packages/p/pam-1.5.1-22.el9_5.x86_64.rpm
     repoid: ubi-9-baseos-rpms
-    size: 647897
-    checksum: sha256:81a26a3089a1b8ef91f603bd882dfaf6732d94cf13c6e1b1c4c3793e6c671bcc
+    size: 647471
+    checksum: sha256:d0c495a13f0c6d0fdefc309086a81e64eb852255ce64a45b766187bd09de41d0
     name: pam
-    evr: 1.5.1-20.el9
-    sourcerpm: pam-1.5.1-20.el9.src.rpm
+    evr: 1.5.1-22.el9_5
+    sourcerpm: pam-1.5.1-22.el9_5.src.rpm
   - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/x86_64/baseos/os/Packages/u/util-linux-2.37.4-20.el9.x86_64.rpm
     repoid: ubi-9-baseos-rpms
     size: 2396057
@@ -3530,24 +3530,24 @@ arches:
     evr: 2.37.4-20.el9
     sourcerpm: util-linux-2.37.4-20.el9.src.rpm
   source:
-  - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/x86_64/appstream/source/SRPMS/Packages/e/emacs-27.2-10.el9_4.src.rpm
+  - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/x86_64/appstream/source/SRPMS/Packages/e/emacs-27.2-11.el9_5.1.src.rpm
     repoid: ubi-9-appstream-source
-    size: 44818364
-    checksum: sha256:310ce0bd588fcd7a502e4eb23f41138a62564a0954af82f3c9c0fd1084c63bfb
+    size: 44822831
+    checksum: sha256:38c5fde02ec16d0b2a9a2a85637e591e9776726e71dcf2b2913a5260855e01b9
     name: emacs
-    evr: 1:27.2-10.el9_4
-  - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/x86_64/appstream/source/SRPMS/Packages/g/git-2.43.5-1.el9_4.src.rpm
+    evr: 1:27.2-11.el9_5.1
+  - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/x86_64/appstream/source/SRPMS/Packages/g/git-2.43.5-2.el9_5.src.rpm
     repoid: ubi-9-appstream-source
-    size: 7444986
-    checksum: sha256:ca1d24f27e78e423b507052cdffff2fc1a182a74bb5a6876a9f3bed1b2078852
+    size: 7447825
+    checksum: sha256:8a13e0b20c35dc7b091d7659f5dd49cbc3dbb442da1f5096bc100e8fc1cd269f
     name: git
-    evr: 2.43.5-1.el9_4
-  - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/x86_64/appstream/source/SRPMS/Packages/g/git-lfs-3.4.1-4.el9_4.src.rpm
+    evr: 2.43.5-2.el9_5
+  - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/x86_64/appstream/source/SRPMS/Packages/g/git-lfs-3.4.1-4.el9_5.src.rpm
     repoid: ubi-9-appstream-source
-    size: 3497003
-    checksum: sha256:c8c011992eb4a6ee9b5b092bfde434c6ca20816c944c32766e30f92d8a8fb2ad
+    size: 3500817
+    checksum: sha256:1ae68536ad47e8da68516935177b71403a9953538e9376c3797b064edcef772e
     name: git-lfs
-    evr: 3.4.1-4.el9_4
+    evr: 3.4.1-4.el9_5
   - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/x86_64/appstream/source/SRPMS/Packages/p/perl-5.32.1-481.el9.src.rpm
     repoid: ubi-9-appstream-source
     size: 12784744
@@ -3848,18 +3848,18 @@ arches:
     checksum: sha256:27fe41a1d639254d73baea0f65bfd90321b1483e4e1ccad5e23db971fbc9db1d
     name: openssh
     evr: 8.7p1-43.el9
-  - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/x86_64/baseos/source/SRPMS/Packages/o/openssl-3.2.2-6.el9_5.src.rpm
+  - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/x86_64/baseos/source/SRPMS/Packages/o/openssl-3.2.2-6.el9_5.1.src.rpm
     repoid: ubi-9-baseos-source
-    size: 17984798
-    checksum: sha256:b58aa63f681560c0c4716ef22de299dcfd3219fd4de4b9f0d363648c59b92f37
+    size: 17985138
+    checksum: sha256:56c0b951be3e5ad6a1da594f9d4f09b8b752e2fb3d6827bcc03892f22f622b22
     name: openssl
-    evr: 1:3.2.2-6.el9_5
-  - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/x86_64/baseos/source/SRPMS/Packages/p/pam-1.5.1-20.el9.src.rpm
+    evr: 1:3.2.2-6.el9_5.1
+  - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/x86_64/baseos/source/SRPMS/Packages/p/pam-1.5.1-22.el9_5.src.rpm
     repoid: ubi-9-baseos-source
-    size: 1107946
-    checksum: sha256:a5edf4974b4ed014068713bc15e657408b622013e2e36ecca2ad1bfb791f67d7
+    size: 1112974
+    checksum: sha256:8224a77bca54712e2cef82141303493602f0403dbcfa8a713b3d48f533d17ff2
     name: pam
-    evr: 1.5.1-20.el9
+    evr: 1.5.1-22.el9_5
   - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/x86_64/baseos/source/SRPMS/Packages/u/util-linux-2.37.4-20.el9.src.rpm
     repoid: ubi-9-baseos-source
     size: 6278844

--- a/.konflux/image-bundler/Dockerfile
+++ b/.konflux/image-bundler/Dockerfile
@@ -6,7 +6,7 @@ COPY build .
 
 RUN CGO_ENABLED=1 GO111MODULE=on go build -a -mod=vendor -ldflags="-s -w" -tags="strictfipsruntime" -o openshift-builds-image-bundler ./cmd/bundle
 
-FROM registry.access.redhat.com/ubi9-minimal@sha256:b87097994ed62fbf1de70bc75debe8dacf3ea6e00dd577d74503ef66452c59d6
+FROM registry.access.redhat.com/ubi9-minimal@sha256:14f14e03d68f7fd5f2b18a13478b6b127c341b346c86b6e0b886ed2b7573b8e0
 
 RUN \
   microdnf clean all && \

--- a/.konflux/image-processing/Dockerfile
+++ b/.konflux/image-processing/Dockerfile
@@ -6,7 +6,7 @@ COPY build .
 
 RUN CGO_ENABLED=1 GO111MODULE=on go build -a -mod=vendor -ldflags="-s -w" -tags="strictfipsruntime" -o openshift-builds-image-processing ./cmd/image-processing
 
-FROM registry.access.redhat.com/ubi9-minimal@sha256:b87097994ed62fbf1de70bc75debe8dacf3ea6e00dd577d74503ef66452c59d6
+FROM registry.access.redhat.com/ubi9-minimal@sha256:14f14e03d68f7fd5f2b18a13478b6b127c341b346c86b6e0b886ed2b7573b8e0
 
 RUN \
   microdnf clean all && \

--- a/.konflux/waiter/Dockerfile
+++ b/.konflux/waiter/Dockerfile
@@ -6,7 +6,7 @@ COPY build .
 
 RUN CGO_ENABLED=1 GO111MODULE=on go build -a -mod=vendor -ldflags="-s -w" -tags="strictfipsruntime" -o openshift-builds-waiter ./cmd/waiter
 
-FROM registry.access.redhat.com/ubi9-minimal@sha256:b87097994ed62fbf1de70bc75debe8dacf3ea6e00dd577d74503ef66452c59d6
+FROM registry.access.redhat.com/ubi9-minimal@sha256:14f14e03d68f7fd5f2b18a13478b6b127c341b346c86b6e0b886ed2b7573b8e0
 
 RUN \
   microdnf --assumeyes --nodocs install tar && \

--- a/.konflux/webhook/Dockerfile
+++ b/.konflux/webhook/Dockerfile
@@ -6,7 +6,7 @@ COPY build .
 
 RUN CGO_ENABLED=1 GO111MODULE=on go build -a -mod=vendor -ldflags="-s -w" -tags="strictfipsruntime" -o openshift-builds-webhook ./cmd/shipwright-build-webhook
 
-FROM registry.access.redhat.com/ubi9-minimal@sha256:b87097994ed62fbf1de70bc75debe8dacf3ea6e00dd577d74503ef66452c59d6
+FROM registry.access.redhat.com/ubi9-minimal@sha256:14f14e03d68f7fd5f2b18a13478b6b127c341b346c86b6e0b886ed2b7573b8e0
 
 COPY --from=builder /opt/app-root/src/openshift-builds-webhook .
 COPY LICENSE /licenses/


### PR DESCRIPTION
- Bump ubi-minimal to 14f14e0
- Update rpms.lock.yaml using rpm-lockfile-prototype tool.