### PR TITLE
Update golang builder image to 1.23

### DIFF
--- a/.konflux/controller/Dockerfile
+++ b/.konflux/controller/Dockerfile
@@ -1,4 +1,4 @@
-FROM registry.access.redhat.com/ubi9/go-toolset@sha256:703937e152d049e62f5aa8ab274a4253468ab70f7b790d92714b37cf0a140555 AS builder
+FROM brew.registry.redhat.io/rh-osbs/openshift-golang-builder:rhel_9_1.23@sha256:44fd8f88f3b6463cda15571260f9ca3a0b78d3c8c8827a338e04ab3a23581a88 AS builder
 
 ENV GOEXPERIMENT=strictfipsruntime
 
@@ -8,7 +8,7 @@ RUN CGO_ENABLED=1 GO111MODULE=on go build -a -mod=vendor -ldflags="-s -w" -tags=
 
 FROM registry.access.redhat.com/ubi9-minimal@sha256:14f14e03d68f7fd5f2b18a13478b6b127c341b346c86b6e0b886ed2b7573b8e0
 
-COPY --from=builder /opt/app-root/src/openshift-builds-controller .
+COPY --from=builder /openshift-builds-controller .
 COPY LICENSE /licenses/
 
 USER 1001

--- a/.konflux/git-cloner/Dockerfile
+++ b/.konflux/git-cloner/Dockerfile
@@ -1,7 +1,7 @@
-FROM registry.access.redhat.com/ubi9/go-toolset@sha256:703937e152d049e62f5aa8ab274a4253468ab70f7b790d92714b37cf0a140555 AS builder
+FROM brew.registry.redhat.io/rh-osbs/openshift-golang-builder:rhel_9_1.23@sha256:44fd8f88f3b6463cda15571260f9ca3a0b78d3c8c8827a338e04ab3a23581a88 AS builder
 
 ENV GOEXPERIMENT=strictfipsruntime
-
+RUN pwd
 COPY build .
 
 RUN CGO_ENABLED=1 GO111MODULE=on go build -a -mod=vendor -ldflags="-s -w" -tags="strictfipsruntime" -o openshift-builds-git-cloner ./cmd/git
@@ -17,7 +17,7 @@ RUN \
   mkdir /.docker && chown 1000:1000 /.docker && \
   mkdir /.ssh && chown 1000:1000 /.ssh
 
-COPY --from=builder /opt/app-root/src/openshift-builds-git-cloner /ko-app/git
+COPY --from=builder /openshift-builds-git-cloner /ko-app/git
 COPY LICENSE /licenses/
 
 USER 1001

--- a/.konflux/image-bundler/Dockerfile
+++ b/.konflux/image-bundler/Dockerfile
@@ -1,4 +1,4 @@
-FROM registry.access.redhat.com/ubi9/go-toolset@sha256:703937e152d049e62f5aa8ab274a4253468ab70f7b790d92714b37cf0a140555 AS builder
+FROM brew.registry.redhat.io/rh-osbs/openshift-golang-builder:rhel_9_1.23@sha256:44fd8f88f3b6463cda15571260f9ca3a0b78d3c8c8827a338e04ab3a23581a88 AS builder
 
 ENV GOEXPERIMENT=strictfipsruntime
 
@@ -16,7 +16,7 @@ RUN \
   mkdir /.docker && \
   chown 1000:1000 /.docker
 
-COPY --from=builder /opt/app-root/src/openshift-builds-image-bundler /ko-app/bundle
+COPY --from=builder /openshift-builds-image-bundler /ko-app/bundle
 COPY LICENSE /licenses/
 
 USER 1001

--- a/.konflux/image-processing/Dockerfile
+++ b/.konflux/image-processing/Dockerfile
@@ -1,4 +1,4 @@
-FROM registry.access.redhat.com/ubi9/go-toolset@sha256:703937e152d049e62f5aa8ab274a4253468ab70f7b790d92714b37cf0a140555 AS builder
+FROM brew.registry.redhat.io/rh-osbs/openshift-golang-builder:rhel_9_1.23@sha256:44fd8f88f3b6463cda15571260f9ca3a0b78d3c8c8827a338e04ab3a23581a88 AS builder
 
 ENV GOEXPERIMENT=strictfipsruntime
 
@@ -16,7 +16,7 @@ RUN \
   mkdir /.docker && \
   chown 1000:1000 /.docker
 
-COPY --from=builder /opt/app-root/src/openshift-builds-image-processing /ko-app/image-processing
+COPY --from=builder /openshift-builds-image-processing /ko-app/image-processing
 COPY LICENSE /licenses/
 
 USER 1001

--- a/.konflux/waiter/Dockerfile
+++ b/.konflux/waiter/Dockerfile
@@ -1,4 +1,4 @@
-FROM registry.access.redhat.com/ubi9/go-toolset@sha256:703937e152d049e62f5aa8ab274a4253468ab70f7b790d92714b37cf0a140555 AS builder
+FROM brew.registry.redhat.io/rh-osbs/openshift-golang-builder:rhel_9_1.23@sha256:44fd8f88f3b6463cda15571260f9ca3a0b78d3c8c8827a338e04ab3a23581a88 AS builder
 
 ENV GOEXPERIMENT=strictfipsruntime
 
@@ -17,7 +17,7 @@ RUN \
   mkdir /.docker && \
   chown 1000:1000 /.docker
 
-COPY --from=builder /opt/app-root/src/openshift-builds-waiter /ko-app/waiter
+COPY --from=builder /openshift-builds-waiter /ko-app/waiter
 COPY LICENSE /licenses/
 
 USER 1001

--- a/.konflux/webhook/Dockerfile
+++ b/.konflux/webhook/Dockerfile
@@ -1,4 +1,4 @@
-FROM registry.access.redhat.com/ubi9/go-toolset@sha256:703937e152d049e62f5aa8ab274a4253468ab70f7b790d92714b37cf0a140555 AS builder
+FROM brew.registry.redhat.io/rh-osbs/openshift-golang-builder:rhel_9_1.23@sha256:44fd8f88f3b6463cda15571260f9ca3a0b78d3c8c8827a338e04ab3a23581a88 AS builder
 
 ENV GOEXPERIMENT=strictfipsruntime
 
@@ -8,7 +8,7 @@ RUN CGO_ENABLED=1 GO111MODULE=on go build -a -mod=vendor -ldflags="-s -w" -tags=
 
 FROM registry.access.redhat.com/ubi9-minimal@sha256:14f14e03d68f7fd5f2b18a13478b6b127c341b346c86b6e0b886ed2b7573b8e0
 
-COPY --from=builder /opt/app-root/src/openshift-builds-webhook .
+COPY --from=builder /openshift-builds-webhook .
 COPY LICENSE /licenses/
 
 USER 1001


### PR DESCRIPTION
Changes:
- Use Red Hat OSBS Golang 1.23 builder image, as Go Toolset for 1.23 is not released yet.