### PR TITLE
Fix multi-arch build

### DIFF
--- a/.konflux/controller/Dockerfile
+++ b/.konflux/controller/Dockerfile
@@ -1,4 +1,4 @@
-FROM brew.registry.redhat.io/rh-osbs/openshift-golang-builder:rhel_9_1.23@sha256:44fd8f88f3b6463cda15571260f9ca3a0b78d3c8c8827a338e04ab3a23581a88 AS builder
+FROM brew.registry.redhat.io/rh-osbs/openshift-golang-builder:rhel_9_1.23 AS builder
 
 ENV GOEXPERIMENT=strictfipsruntime
 

--- a/.konflux/git-cloner/Dockerfile
+++ b/.konflux/git-cloner/Dockerfile
@@ -1,4 +1,4 @@
-FROM brew.registry.redhat.io/rh-osbs/openshift-golang-builder:rhel_9_1.23@sha256:44fd8f88f3b6463cda15571260f9ca3a0b78d3c8c8827a338e04ab3a23581a88 AS builder
+FROM brew.registry.redhat.io/rh-osbs/openshift-golang-builder:rhel_9_1.23 AS builder
 
 ENV GOEXPERIMENT=strictfipsruntime
 RUN pwd

--- a/.konflux/image-bundler/Dockerfile
+++ b/.konflux/image-bundler/Dockerfile
@@ -1,4 +1,4 @@
-FROM brew.registry.redhat.io/rh-osbs/openshift-golang-builder:rhel_9_1.23@sha256:44fd8f88f3b6463cda15571260f9ca3a0b78d3c8c8827a338e04ab3a23581a88 AS builder
+FROM brew.registry.redhat.io/rh-osbs/openshift-golang-builder:rhel_9_1.23 AS builder
 
 ENV GOEXPERIMENT=strictfipsruntime
 

--- a/.konflux/image-processing/Dockerfile
+++ b/.konflux/image-processing/Dockerfile
@@ -1,4 +1,4 @@
-FROM brew.registry.redhat.io/rh-osbs/openshift-golang-builder:rhel_9_1.23@sha256:44fd8f88f3b6463cda15571260f9ca3a0b78d3c8c8827a338e04ab3a23581a88 AS builder
+FROM brew.registry.redhat.io/rh-osbs/openshift-golang-builder:rhel_9_1.23 AS builder
 
 ENV GOEXPERIMENT=strictfipsruntime
 

--- a/.konflux/waiter/Dockerfile
+++ b/.konflux/waiter/Dockerfile
@@ -1,4 +1,4 @@
-FROM brew.registry.redhat.io/rh-osbs/openshift-golang-builder:rhel_9_1.23@sha256:44fd8f88f3b6463cda15571260f9ca3a0b78d3c8c8827a338e04ab3a23581a88 AS builder
+FROM brew.registry.redhat.io/rh-osbs/openshift-golang-builder:rhel_9_1.23 AS builder
 
 ENV GOEXPERIMENT=strictfipsruntime
 

--- a/.konflux/webhook/Dockerfile
+++ b/.konflux/webhook/Dockerfile
@@ -1,4 +1,4 @@
-FROM brew.registry.redhat.io/rh-osbs/openshift-golang-builder:rhel_9_1.23@sha256:44fd8f88f3b6463cda15571260f9ca3a0b78d3c8c8827a338e04ab3a23581a88 AS builder
+FROM brew.registry.redhat.io/rh-osbs/openshift-golang-builder:rhel_9_1.23 AS builder
 
 ENV GOEXPERIMENT=strictfipsruntime
 

--- a/.tekton/openshift-builds-controller-pull-request.yaml
+++ b/.tekton/openshift-builds-controller-pull-request.yaml
@@ -41,6 +41,7 @@ spec:
   - name: build-platforms
     value:
       - linux/x86_64
+      - linux/arm64
   - name: prefetch-input
     value: '{"packages": [{"type": "gomod", "path": "build"}]}'
   pipelineRef:

--- a/.tekton/openshift-builds-git-cloner-pull-request.yaml
+++ b/.tekton/openshift-builds-git-cloner-pull-request.yaml
@@ -43,6 +43,7 @@ spec:
   - name: build-platforms
     value:
       - linux/x86_64
+      - linux/arm64
   - name: prefetch-input
     value: '{"packages": [{"type": "gomod", "path": "build"},{"type": "rpm","path": ".konflux/git-cloner"}]}'
   pipelineRef:

--- a/.tekton/openshift-builds-image-bundler-pull-request.yaml
+++ b/.tekton/openshift-builds-image-bundler-pull-request.yaml
@@ -41,6 +41,7 @@ spec:
   - name: build-platforms
     value:
       - linux/x86_64
+      - linux/arm64
   - name: prefetch-input
     value: '{"packages": [{"type": "gomod", "path": "build"}]}'
   pipelineRef:

--- a/.tekton/openshift-builds-image-processing-pull-request.yaml
+++ b/.tekton/openshift-builds-image-processing-pull-request.yaml
@@ -41,6 +41,7 @@ spec:
   - name: build-platforms
     value:
       - linux/x86_64
+      - linux/arm64
   - name: prefetch-input
     value: '{"packages": [{"type": "gomod", "path": "build"}]}'
   pipelineRef:

--- a/.tekton/openshift-builds-waiter-pull-request.yaml
+++ b/.tekton/openshift-builds-waiter-pull-request.yaml
@@ -43,6 +43,7 @@ spec:
   - name: build-platforms
     value:
       - linux/x86_64
+      - linux/arm64
   - name: prefetch-input
     value: '{"packages": [{"type": "gomod", "path": "build"},{"type": "rpm","path": ".konflux/waiter"}]}'
   pipelineRef:

--- a/.tekton/openshift-builds-webhook-pull-request.yaml
+++ b/.tekton/openshift-builds-webhook-pull-request.yaml
@@ -41,6 +41,7 @@ spec:
   - name: build-platforms
     value:
       - linux/x86_64
+      - linux/arm64
   - name: prefetch-input
     value: '{"packages": [{"type": "gomod", "path": "build"}]}'
   pipelineRef:


### PR DESCRIPTION
Changes:
- Update golang 1.23 builder image to use multi-arch manifest
- Add linux/arm64 build in pull request