### PR TITLE
chore(KONFLUX-6210): fix and set name and cpe label for openshift-builds-webhook-1-5

### DIFF
--- a/.konflux/webhook/Dockerfile
+++ b/.konflux/webhook/Dockerfile
@@ -19,11 +19,12 @@ ENTRYPOINT ["./openshift-builds-webhook"]
 
 LABEL \
     com.redhat.component="openshift-builds-webhook" \
-    name="openshift-builds/webhook" \
+    name="openshift-builds/openshift-builds-webhook-rhel9" \
     version="v1.4.0" \
     summary="Red Hat OpenShift Builds webhook" \
     maintainer="openshift-builds@redhat.com" \
     description="Red Hat OpenShift Builds webhook" \
     io.k8s.description="Red Hat OpenShift Builds Webhook" \
     io.k8s.display-name="Red Hat OpenShift Builds Webhook" \
-    io.openshift.tags="builds,conversion-webhook"
+    io.openshift.tags="builds,conversion-webhook" \
+    cpe="cpe:/a:redhat:openshift_builds:1.5::el9"


### PR DESCRIPTION
For https://issues.redhat.com/browse/KONFLUX-6210, clair needs access to a name and cpe label that it can use to look up the image in VEX statements.

See also release-engineering/rhtap-ec-policy#149

Signed-off-by: Ralph Bean <rbean@redhat.com>
Assisted-by: Gemini
