### PR TITLE
chore(KONFLUX-6210): fix and set name and cpe label for openshift-builds-image-processing-1-5

### DIFF
--- a/.konflux/image-processing/Dockerfile
+++ b/.konflux/image-processing/Dockerfile
@@ -30,11 +30,12 @@ ENTRYPOINT ["/ko-app/image-processing"]
 
 LABEL \
     com.redhat.component="openshift-builds-image-processing" \
-    name="openshift-builds/image-processing" \
+    name="openshift-builds/openshift-builds-image-processing-rhel9" \
     version="v1.4.0" \
     summary="Red Hat OpenShift Builds Image Processing" \
     maintainer="openshift-builds@redhat.com" \
     description="Red Hat OpenShift Builds Image Processing" \
     io.k8s.description="Red Hat OpenShift Builds Image Processing" \
     io.k8s.display-name="Red Hat OpenShift Builds Image Processing" \
-    io.openshift.tags="builds,image-processing"
+    io.openshift.tags="builds,image-processing" \
+    cpe="cpe:/a:redhat:openshift_builds:1.5::el9"


### PR DESCRIPTION
For https://issues.redhat.com/browse/KONFLUX-6210, clair needs access to a name and cpe label that it can use to look up the image in VEX statements.

See also release-engineering/rhtap-ec-policy#149

Signed-off-by: Ralph Bean <rbean@redhat.com>
Assisted-by: Gemini
