### PR TITLE
chore(KONFLUX-6210): fix and set name and cpe label for openshift-builds-image-bundler-1-5

### DIFF
--- a/.konflux/image-bundler/Dockerfile
+++ b/.konflux/image-bundler/Dockerfile
@@ -19,11 +19,12 @@ ENTRYPOINT ["/ko-app/bundle"]
 
 LABEL \
     com.redhat.component="openshift-builds-image-bundler" \
-    name="openshift-builds/image-bundler" \
+    name="openshift-builds/openshift-builds-image-bundler-rhel9" \
     version="v1.4.0" \
     summary="Red Hat OpenShift Builds Image Bundler" \
     maintainer="openshift-builds@redhat.com" \
     description="Red Hat OpenShift Builds Image Bundler" \
     io.k8s.description="Red Hat OpenShift Builds Image Bundler" \
     io.k8s.display-name="Red Hat OpenShift Builds Image Bundler" \
-    io.openshift.tags="builds,image-bundler"
+    io.openshift.tags="builds,image-bundler" \
+    cpe="cpe:/a:redhat:openshift_builds:1.5::el9"


### PR DESCRIPTION
For https://issues.redhat.com/browse/KONFLUX-6210, clair needs access to a name and cpe label that it can use to look up the image in VEX statements.

See also release-engineering/rhtap-ec-policy#149

Signed-off-by: Ralph Bean <rbean@redhat.com>
Assisted-by: Gemini
