### PR TITLE
chore(KONFLUX-6210): fix and set name and cpe label for openshift-builds-git-cloner-1-5

### DIFF
--- a/.konflux/git-cloner/Dockerfile
+++ b/.konflux/git-cloner/Dockerfile
@@ -31,11 +31,12 @@ ENTRYPOINT ["/ko-app/git"]
 
 LABEL \
     com.redhat.component="openshift-builds-git-cloner" \
-    name="openshift-builds/git-cloner" \
+    name="openshift-builds/openshift-builds-git-cloner-rhel9" \
     version="v1.4.0" \
     summary="Red Hat OpenShift Builds Git Cloner" \
     maintainer="openshift-builds@redhat.com" \
     description="Red Hat OpenShift Builds Git Cloner" \
     io.k8s.description="Red Hat OpenShift Builds Git Cloner" \
     io.k8s.display-name="Red Hat OpenShift Builds Git Cloner" \
-    io.openshift.tags="builds,git-cloner"
+    io.openshift.tags="builds,git-cloner" \
+    cpe="cpe:/a:redhat:openshift_builds:1.5::el9"


### PR DESCRIPTION
For https://issues.redhat.com/browse/KONFLUX-6210, clair needs access to a name and cpe label that it can use to look up the image in VEX statements.

See also release-engineering/rhtap-ec-policy#149

Signed-off-by: Ralph Bean <rbean@redhat.com>
Assisted-by: Gemini
