### PR TITLE
chore(KONFLUX-6210): fix and set name and cpe label for openshift-builds-controller-1-5

### DIFF
--- a/.konflux/controller/Dockerfile
+++ b/.konflux/controller/Dockerfile
@@ -19,7 +19,8 @@ ENTRYPOINT ["./openshift-builds-controller"]
 
 LABEL \
     com.redhat.component="openshift-builds-controller" \
-    name="openshift-builds/controller" \
+    name="openshift-builds/openshift-builds-controller-rhel9" \
+    cpe="cpe:/a:redhat:openshift_builds:1.5::el9" \
     version="v1.4.0" \
     summary="Red Hat OpenShift Builds Controller" \
     maintainer="openshift-builds@redhat.com" \


### PR DESCRIPTION
For https://issues.redhat.com/browse/KONFLUX-6210, clair needs access to a name and cpe label that it can use to look up the image in VEX statements.

See also release-engineering/rhtap-ec-policy#149

Signed-off-by: Ralph Bean <rbean@redhat.com>
Assisted-by: Gemini
