### PR TITLE
chore(KONFLUX-6210): fix and set name and cpe label for openshift-builds-waiter-1-4

### DIFF
--- a/.konflux/waiter/Dockerfile
+++ b/.konflux/waiter/Dockerfile
@@ -31,8 +31,9 @@ ENTRYPOINT ["/ko-app/waiter"]
 
 LABEL \
     com.redhat.component="openshift-builds-waiter" \
-    name="openshift-builds/waiter" \
+    name="openshift-builds/openshift-builds-waiters-rhel9" \
     version="v1.4.0" \
+    cpe="cpe:/a:redhat:openshift_builds:1.4::el9" \
     summary="Red Hat OpenShift Builds Waiter" \
     maintainer="openshift-builds@redhat.com" \
     description="Red Hat OpenShift Builds Waiter" \


### PR DESCRIPTION
For https://issues.redhat.com/browse/KONFLUX-6210, clair needs access to a name and cpe label that it can use to look up the image in VEX statements.

See also release-engineering/rhtap-ec-policy#149

Signed-off-by: Ralph Bean <rbean@redhat.com>
Assisted-by: Gemini
