### PR TITLE
chore(KONFLUX-6210): fix and set name and cpe label for openshift-builds-image-bundler-1-4

### DIFF
--- a/.konflux/image-bundler/Dockerfile
+++ b/.konflux/image-bundler/Dockerfile
@@ -19,8 +19,9 @@ ENTRYPOINT ["/ko-app/bundle"]
 
 LABEL \
     com.redhat.component="openshift-builds-image-bundler" \
-    name="openshift-builds/image-bundler" \
+    name="openshift-builds/openshift-builds-image-bundler-rhel9" \
     version="v1.4.0" \
+    cpe="cpe:/a:redhat:openshift_builds:1.4::el9" \
     summary="Red Hat OpenShift Builds Image Bundler" \
     maintainer="openshift-builds@redhat.com" \
     description="Red Hat OpenShift Builds Image Bundler" \


### PR DESCRIPTION
For https://issues.redhat.com/browse/KONFLUX-6210, clair needs access to a name and cpe label that it can use to look up the image in VEX statements.

See also release-engineering/rhtap-ec-policy#149

Signed-off-by: Ralph Bean <rbean@redhat.com>
Assisted-by: Gemini
