### PR TITLE
[BUILD-1851] fix: update .gitmodules to point submodules to Red Hat forks

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,8 +1,6 @@
 [submodule "cli"]
 	path = cli
-	url = https://github.com/shipwright-io/cli.git
-	branch = main
+	url = https://github.com/redhat-openshift-builds/shipwright-io-cli.git
 [submodule "build"]
 	path = build
-	url = https://github.com/shipwright-io/build.git
-	branch = main
+	url = https://github.com/redhat-openshift-builds/shipwright-io-build.git


### PR DESCRIPTION
## Summary

- Update submodule URLs from `shipwright-io/build` and `shipwright-io/cli` to `redhat-openshift-builds/shipwright-io-build` and `redhat-openshift-builds/shipwright-io-cli`
- Remove `branch = main` directives from both submodule entries so SHAs are only updated via deliberate PRs
- Core decoupling step for BUILD-1851

Co-Authored-By: Claude Opus 4.6