### PR TITLE
[BUILD-1853] feat: add update-mirror script and Claude skill

### DIFF
--- a/.claude/skills/update-upstream/SKILL.md
+++ b/.claude/skills/update-upstream/SKILL.md
@@ -1,0 +1,195 @@
+---
+name: update-upstream
+description: Bump build and/or cli submodule SHAs, commit, and create a PR. Usage: /update-upstream build=<sha> cli=<sha> (one or both).
+---
+
+# Update Upstream Submodules
+
+Bumps `build` and/or `cli` submodule pointers to specific upstream commits, commits the change, and creates PRs.
+
+Each submodule gets its own PR with a specific title that triggers the correct Konflux/Tekton pipelines.
+
+## Arguments
+
+The user invoked this with: $ARGUMENTS
+
+Parse submodule=SHA pairs from arguments. Suggested input format:
+
+```
+/update-upstream build=abc123 cli=def456
+```
+
+At least one submodule must be provided. Both are optional.
+
+## Workflow
+
+### 1. Parse Arguments
+
+Extract `build=<sha>` and/or `cli=<sha>` from `$ARGUMENTS`.
+If neither is found, ask the user which submodule(s) to bump and to what SHA.
+
+After parsing, print this info block:
+
+```
+INFO: Each submodule bump creates a separate PR because Konflux pipelines
+use PR title prefixes to decide which pipelines to run:
+- "chore(deps): update build digest" triggers build component pipelines
+- "chore(deps): update cli digest" triggers client pipeline
+```
+
+### 2. Ask for Release Version
+
+Ask the user for the release version (e.g., `v0.19`, `v0.20`).
+This will be used in the branch name.
+
+### 3. Detect GitHub User
+
+```bash
+GH_USER=$(gh api user --jq '.login')
+echo "Logged in as: $GH_USER"
+```
+
+No hardcoded usernames. Works for any developer with `gh auth login` done.
+If this fails, stop and ask the user to run `gh auth login`.
+
+### 4. Verify Remotes
+
+```bash
+FETCH_URL=$(git remote get-url origin)
+PUSH_URL=$(git remote get-url --push origin)
+echo "Fetch: $FETCH_URL"
+echo "Push:  $PUSH_URL"
+```
+
+- Fetch URL must contain `redhat-openshift-builds/shipwright-io`
+- If FETCH_URL != PUSH_URL, this is a fork workflow -- extract fork owner from PUSH_URL
+- If they are the same, the user has direct push access (no fork)
+
+### 5. Check for Dirty Working Tree
+
+```bash
+git status --porcelain
+```
+
+If there are uncommitted changes, stop and offer to help:
+- Stash changes (`git stash`)
+- Commit changes
+- Discard changes
+
+Do not proceed until the working tree is clean.
+
+### 6. Per-Submodule Workflow
+
+For each submodule provided, run steps 6a-6g **sequentially**. If both submodules are provided, complete the full workflow for `build` first, then return to main and repeat for `cli`.
+
+#### 6a. Prepare Branch
+
+```bash
+git checkout main
+git pull origin main
+git checkout -b bump-<submodule>-<release>
+```
+
+Example: `bump-build-v0.19`, `bump-cli-v0.19`.
+
+#### 6b. Run update-upstream.sh
+
+```bash
+./hack/update-upstream.sh <submodule> <sha>
+```
+
+If the invocation fails, stop and report the error.
+
+#### 6c. Show Diff
+
+```bash
+git diff --cached
+```
+
+Print the diff to screen. Tell the user: "Changes are staged. You can also review them in your IDE."
+
+#### 6d. Commit
+
+Always sign with `-s` (DCO) and `-S` (GPG).
+
+```bash
+git commit -s -S -m "$(cat <<'EOF'
+chore(deps): update <submodule> digest to <short-new-sha>
+
+Update <submodule> from <short-old-sha> to <short-new-sha>.
+
+Co-Authored-By: Claude Opus 4.6
+EOF
+)"
+```
+
+#### 6e. Push
+
+```bash
+git push -u origin <branch-name>
+```
+
+#### 6f. Create PR
+
+Extract upstream repo and fork owner from the remotes detected in step 4:
+
+```bash
+UPSTREAM_SLUG=$(echo "$FETCH_URL" | sed 's/.*github.com[:/]\(.*\)\.git/\1/')
+FORK_OWNER=$(echo "$PUSH_URL" | sed 's/.*github.com[:/]\([^/]*\).*/\1/')
+```
+
+PR title must exactly match the pipeline trigger prefix:
+- Build: `chore(deps): update build digest to <short-new-sha>`
+- CLI: `chore(deps): update cli digest to <short-new-sha>`
+
+If fork workflow (FETCH_URL != PUSH_URL):
+```bash
+gh pr create --repo "$UPSTREAM_SLUG" --base main \
+  --head "$FORK_OWNER:<branch-name>" \
+  --title "chore(deps): update <submodule> digest to <short-new-sha>" \
+  --body "$(cat <<'EOF'
+## Summary
+
+- Bump <submodule> submodule from <short-old-sha> to <short-new-sha>
+
+Co-Authored-By: Claude Opus 4.6
+EOF
+)"
+```
+
+If direct push (FETCH_URL == PUSH_URL):
+```bash
+gh pr create --base main \
+  --title "chore(deps): update <submodule> digest to <short-new-sha>" \
+  --body "<same body as above>"
+```
+
+#### 6g. Print Warning
+
+After each PR is created, print:
+
+```
+WARNING: Do NOT change the PR title. The Konflux/Tekton pipelines use
+the title prefix to trigger the correct pipelines. Changing the title
+will prevent pipelines from running.
+```
+
+### 7. Print Summary
+
+Display:
+- Branch name(s)
+- Submodule(s) bumped with old -> new SHAs
+- PR URL(s)
+
+## Key Rules
+
+1. **Detect GitHub username dynamically** via `gh api user` -- never hardcode usernames
+2. **Always sign commits** with `-s -S` (DCO sign-off + GPG)
+3. **Never `git add .`** -- the script handles staging specific submodule paths
+4. **Never use `git submodule update --remote`** -- explicit SHAs only
+5. **Show diff before committing** -- print to screen, suggest IDE review
+6. **Co-author line**: `Co-Authored-By: Claude Opus 4.6`
+7. **Fork workflow**: detect from remotes, push to fork, PR against upstream
+8. **Clean working tree required** -- check and offer help before proceeding
+9. **One PR per submodule** -- each submodule gets its own branch, commit, and PR
+10. **PR titles must match pipeline triggers exactly** -- never modify the title format

--- a/.claude/skills/update-upstream/SKILL.md
+++ b/.claude/skills/update-upstream/SKILL.md
@@ -1,0 +1,185 @@
+---
+name: update-upstream
+description: Bump submodule SHAs on builds-X.Y branch to latest from mirror repos. For z-stream releases. Creates 2 separate PRs (one per submodule).
+argument-hint: "[build] [cli] [build=<sha>] [cli=<sha>]"
+allowed-tools: [Bash, Read]
+user_invocable: true
+---
+
+# Update Mirror Submodule SHAs (Z-Stream)
+
+Bumps `build` and/or `cli` submodule SHAs on the downstream `builds-X.Y` branch to the latest commit from the mirror repos' tracked branch. For z-stream (patch) releases.
+
+Creates separate PRs per submodule for pipeline trigger reasons.
+
+## Arguments
+
+The user invoked this with: $ARGUMENTS
+
+Parse optional arguments:
+- `build` — update only the build submodule
+- `cli` — update only the cli submodule
+- `build=<sha>` — update build to a specific SHA
+- `cli=<sha>` — update cli to a specific SHA
+- No arguments — update both (default)
+
+## Workflow
+
+### 1. Ask for Release Version
+
+Ask the user: "What is the release version? (format: X.Y, e.g., 1.8)"
+
+Do NOT use AskUserQuestion tool — just ask directly and wait for the user to respond.
+
+**Validation**: Ensure the version matches `^[0-9]+\.[0-9]+$`.
+
+Store as `DOT_VERSION`. Derive `DASH_VERSION` by replacing `.` with `-`.
+
+### 2. Checkout Release Branch
+
+```bash
+git checkout "builds-$DOT_VERSION"
+git pull origin "builds-$DOT_VERSION"
+```
+
+### 3. Detect GitHub User and Verify Remotes
+
+```bash
+GH_USER=$(gh api user --jq '.login')
+echo "Logged in as: $GH_USER"
+```
+
+```bash
+FETCH_URL=$(git remote get-url origin)
+PUSH_URL=$(git remote get-url --push origin)
+```
+
+Detect fork workflow: if FETCH_URL != PUSH_URL, extract fork owner from PUSH_URL.
+
+### 4. Check for Dirty Working Tree
+
+```bash
+git status --porcelain -uno
+```
+
+If dirty, stop and offer to stash/commit/discard. Do not proceed until clean.
+
+### 5. Show Current State and Commit Summary
+
+For each submodule (build and cli):
+
+```bash
+CURRENT_SHA=$(git -C <submodule> rev-parse HEAD)
+CURRENT_SHORT=$(git -C <submodule> rev-parse --short HEAD)
+
+git -C <submodule> fetch origin
+
+if [ -n "$EXPLICIT_SHA" ]; then
+  TARGET_SHA="$EXPLICIT_SHA"
+  TARGET_SHORT=$(echo "$TARGET_SHA" | cut -c1-8)
+else
+  TRACKED_BRANCH=$(git config -f .gitmodules --get "submodule.<submodule>.branch")
+  TARGET_SHA=$(git -C <submodule> rev-parse "origin/$TRACKED_BRANCH")
+  TARGET_SHORT=$(git -C <submodule> rev-parse --short "origin/$TRACKED_BRANCH")
+fi
+
+NEW_COMMITS=$(git -C <submodule> rev-list --count "$CURRENT_SHA..$TARGET_SHA" 2>/dev/null || echo "?")
+
+echo ""
+echo "=== <submodule> ==="
+echo "Current: $CURRENT_SHORT"
+echo "Latest:  $TARGET_SHORT"
+echo "New commits: $NEW_COMMITS"
+echo ""
+git -C <submodule> log --oneline "$CURRENT_SHA..$TARGET_SHA" 2>/dev/null | head -20
+```
+
+If `NEW_COMMITS` is 0, display: "✓ <submodule> is already up to date." and skip it.
+
+### 6. Ask User What to Update
+
+If no explicit args were provided, ask the user:
+
+"Update both submodules, just build, or just cli? (both/build/cli)"
+
+Do NOT use AskUserQuestion tool. Default: both.
+
+### 7. Per-Submodule Workflow
+
+For each submodule to update, run steps 7a–7f **sequentially**. Complete build first, then cli.
+
+#### 7a. Prepare Branch
+
+```bash
+git checkout "builds-$DOT_VERSION"
+git checkout -b "bump-<submodule>-$DASH_VERSION"
+```
+
+#### 7b. Update Submodule
+
+```bash
+if [ -n "$EXPLICIT_SHA" ]; then
+  ./hack/update-upstream.sh <submodule> "$EXPLICIT_SHA"
+else
+  ./hack/update-upstream.sh <submodule>
+fi
+```
+
+#### 7c. Show Diff
+
+```bash
+git diff --cached
+```
+
+Print the diff to screen.
+
+#### 7d. Commit
+
+```bash
+NEW_SHA=$(git -C <submodule> rev-parse --short HEAD)
+OLD_SHA="$CURRENT_SHORT"
+
+git commit -s -S -m "$(cat <<'EOF'
+chore(deps): update <submodule> digest to <NEW_SHA>
+
+Update <submodule> from <OLD_SHA> to <NEW_SHA>.
+
+Co-Authored-By: Claude Opus 4.6
+EOF
+)"
+```
+
+#### 7e. Push and Create PR
+
+```bash
+git push -u origin "bump-<submodule>-$DASH_VERSION"
+```
+
+PR title must exactly match:
+- Build: `chore(deps): update build digest to <NEW_SHA>`
+- CLI: `chore(deps): update cli digest to <NEW_SHA>`
+
+Use fork workflow detection to create PR correctly.
+
+#### 7f. Print Warning
+
+```
+WARNING: Do NOT change the PR title. The Konflux/Tekton pipelines use
+the title prefix to trigger the correct pipelines.
+```
+
+Return to release branch: `git checkout "builds-$DOT_VERSION"`
+
+### 8. Print Summary
+
+Show table with submodule, old SHA, new SHA, new commits count, and PR URL.
+
+## Key Rules
+
+1. **Detect GitHub username dynamically** via `gh api user`
+2. **Always sign commits** with `-s -S` (DCO sign-off + GPG)
+3. **One PR per submodule** — each gets its own branch, commit, and PR
+4. **PR titles must match pipeline triggers exactly**
+5. **Show commit summary before updating** — user sees what changed
+6. **Sequential execution** — complete build fully before starting cli
+7. **Co-author line**: `Co-Authored-By: Claude Opus 4.6`

--- a/README.md
+++ b/README.md
@@ -61,3 +61,37 @@ The `rpms.lock.yaml` file contains resolved dependencies for packages needed by 
 - **Podman errors**: Ensure Podman Desktop is running and the machine is started
 - **Network issues**: Verify internet connectivity to access UBI repositories
 - **Permission errors**: The container runs as the current user, so file permissions should be preserved
+
+## Bumping Upstream Submodules
+
+This repo tracks the `build` and `cli` upstream repositories as git submodules pointing at Red Hat mirror repos. Submodule SHAs are bumped deliberately -- there is no auto-tracking of upstream branches.
+
+### Prerequisites
+
+- `gh` CLI authenticated (`gh auth login`)
+- [Claude Code](https://docs.anthropic.com/en/docs/claude-code) (recommended)
+
+### Using the Claude Code skill (recommended)
+
+The `/update-upstream` skill handles the full workflow: branch creation, SHA validation, submodule checkout, commit with signing, and PR creation.
+
+```
+/update-upstream build=<sha>
+/update-upstream cli=<sha>
+/update-upstream build=<sha> cli=<sha>
+```
+
+When both submodules are provided, the skill creates **two separate PRs** -- one per submodule. This is required because Konflux pipelines use the PR title prefix (`chore(deps): update build digest` or `chore(deps): update cli digest`) to decide which pipelines to run. Do not change the PR titles after creation.
+
+### Using the script directly
+
+The underlying script can also be run manually:
+
+```bash
+./hack/update-upstream.sh <submodule> <sha>
+```
+
+- `<submodule>` -- must be `build` or `cli`
+- `<sha>` -- the target commit SHA from the mirror repo (7-40 hex characters)
+
+The script validates the SHA against the mirror repo, fetches, checks out the target commit, and stages the change. You then commit and create a PR manually.

--- a/README.md
+++ b/README.md
@@ -61,3 +61,39 @@ The `rpms.lock.yaml` file contains resolved dependencies for packages needed by 
 - **Podman errors**: Ensure Podman Desktop is running and the machine is started
 - **Network issues**: Verify internet connectivity to access UBI repositories
 - **Permission errors**: The container runs as the current user, so file permissions should be preserved
+
+## Bumping Upstream Submodules
+
+This repo tracks the `build` and `cli` upstream repositories as git submodules pointing at Red Hat mirror repos. Submodule SHAs are bumped deliberately -- there is no auto-tracking of upstream branches.
+
+### Prerequisites
+
+- `gh` CLI authenticated (`gh auth login`)
+- [Claude Code](https://docs.anthropic.com/en/docs/claude-code) (recommended)
+
+### Using the Claude Code skill (recommended)
+
+The `/update-upstream` skill handles the full workflow for z-stream (patch) releases on `builds-X.Y` branches. It shows commit summaries, validates, checks out submodule SHAs, commits with signing, and creates PRs.
+
+```
+/update-upstream
+/update-upstream build
+/update-upstream cli
+/update-upstream build=<sha>
+/update-upstream cli=<sha>
+```
+
+When no SHA is specified, the skill updates to the latest commit from the tracked branch in `.gitmodules`. When both submodules are updated, the skill creates **two separate PRs** -- one per submodule. This is required because Konflux pipelines use the PR title prefix (`chore(deps): update build digest` or `chore(deps): update cli digest`) to decide which pipelines to run. Do not change the PR titles after creation.
+
+### Using the script directly
+
+The underlying script can also be run manually:
+
+```bash
+./hack/update-upstream.sh <submodule> [sha]
+```
+
+- `<submodule>` -- must be `build` or `cli`
+- `<sha>` -- (optional) the target commit SHA from the mirror repo (7-40 hex characters). If omitted, updates to the latest commit from the tracked branch in `.gitmodules`.
+
+The script validates the SHA (if provided) against the mirror repo, fetches, checks out the target commit, and stages the change. You then commit and create a PR manually.

--- a/hack/test-update-upstream.sh
+++ b/hack/test-update-upstream.sh
@@ -1,0 +1,165 @@
+#!/bin/bash
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+REPO_ROOT="$(cd "$SCRIPT_DIR/.." && pwd)"
+SCRIPT="$SCRIPT_DIR/update-upstream.sh"
+
+PASS=0
+FAIL=0
+
+pass() { ((PASS++)); echo "  PASS: $1"; }
+fail() { ((FAIL++)); echo "  FAIL: $1 — $2"; }
+
+assert_exit() {
+    local desc="$1" expected_exit="$2" actual_exit="$3" output="$4"
+    if [[ "$actual_exit" -eq "$expected_exit" ]]; then
+        pass "$desc"
+    else
+        fail "$desc" "expected exit $expected_exit, got $actual_exit. Output: $output"
+    fi
+}
+
+assert_output_contains() {
+    local desc="$1" pattern="$2" output="$3"
+    if echo "$output" | grep -qi "$pattern"; then
+        pass "$desc"
+    else
+        fail "$desc" "output missing '$pattern'"
+    fi
+}
+
+revert_submodule() {
+    local sub="$1"
+    git -C "$REPO_ROOT" reset HEAD "$sub" >/dev/null 2>&1 || true
+    git -C "$REPO_ROOT" submodule update --init "$sub" >/dev/null 2>&1
+}
+
+cd "$REPO_ROOT"
+
+# ============================================================
+echo ""
+echo "=== Group 1: Input Validation ==="
+echo ""
+
+# Test 1: No args
+echo "Test 1: No args"
+output=$("$SCRIPT" 2>&1 || true)
+exit_code=0; "$SCRIPT" >/dev/null 2>&1 || exit_code=$?
+assert_exit "exits non-zero" 1 "$exit_code" "$output"
+assert_output_contains "prints usage" "Usage" "$output"
+
+# Test 2: Too many args
+echo "Test 2: Too many args"
+output=$("$SCRIPT" build abc123f extra 2>&1 || true)
+exit_code=0; "$SCRIPT" build abc123f extra >/dev/null 2>&1 || exit_code=$?
+assert_exit "exits non-zero" 1 "$exit_code" "$output"
+assert_output_contains "prints usage" "Usage" "$output"
+
+# Test 3: Invalid submodule name
+echo "Test 3: Invalid submodule name"
+output=$("$SCRIPT" foo 2>&1 || true)
+exit_code=0; "$SCRIPT" foo >/dev/null 2>&1 || exit_code=$?
+assert_exit "exits non-zero" 1 "$exit_code" "$output"
+assert_output_contains "error message" "must be 'build' or 'cli'" "$output"
+
+# Test 4: Invalid SHA format (too short)
+echo "Test 4: Invalid SHA (too short)"
+output=$("$SCRIPT" build abc 2>&1 || true)
+exit_code=0; "$SCRIPT" build abc >/dev/null 2>&1 || exit_code=$?
+assert_exit "exits non-zero" 1 "$exit_code" "$output"
+assert_output_contains "error message" "not a valid SHA" "$output"
+
+# Test 5: Invalid SHA format (non-hex)
+echo "Test 5: Invalid SHA (non-hex)"
+output=$("$SCRIPT" build ZZZZZZZZ 2>&1 || true)
+exit_code=0; "$SCRIPT" build ZZZZZZZZ >/dev/null 2>&1 || exit_code=$?
+assert_exit "exits non-zero" 1 "$exit_code" "$output"
+assert_output_contains "error message" "not a valid SHA" "$output"
+
+# Test 6: SHA not found in remote (requires network)
+echo "Test 6: SHA not found in remote"
+FAKE_SHA="aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
+output=$("$SCRIPT" build "$FAKE_SHA" 2>&1 || true)
+exit_code=0; "$SCRIPT" build "$FAKE_SHA" >/dev/null 2>&1 || exit_code=$?
+assert_exit "exits non-zero" 1 "$exit_code" "$output"
+assert_output_contains "error message" "not found in" "$output"
+
+# ============================================================
+echo ""
+echo "=== Group 2: Core Functionality ==="
+echo ""
+
+# Test 7: Update build to latest (no SHA)
+echo "Test 7: Update build to latest"
+original_sha=$(git -C build rev-parse HEAD)
+exit_code=0; output=$("$SCRIPT" build 2>&1) || exit_code=$?
+assert_exit "exits zero" 0 "$exit_code" "$output"
+new_sha=$(git -C build rev-parse HEAD)
+assert_output_contains "shows update summary" "submodule updated" "$output"
+revert_submodule build
+reverted_sha=$(git -C build rev-parse HEAD)
+if [[ "$reverted_sha" == "$original_sha" ]]; then
+    pass "reverted successfully"
+else
+    fail "reverted successfully" "SHA after revert ($reverted_sha) != original ($original_sha)"
+fi
+
+# Test 8: Update cli to latest (no SHA)
+echo "Test 8: Update cli to latest"
+original_sha=$(git -C cli rev-parse HEAD)
+exit_code=0; output=$("$SCRIPT" cli 2>&1) || exit_code=$?
+assert_exit "exits zero" 0 "$exit_code" "$output"
+assert_output_contains "shows update summary" "submodule updated" "$output"
+revert_submodule cli
+reverted_sha=$(git -C cli rev-parse HEAD)
+if [[ "$reverted_sha" == "$original_sha" ]]; then
+    pass "reverted successfully"
+else
+    fail "reverted successfully" "SHA after revert ($reverted_sha) != original ($original_sha)"
+fi
+
+# Test 9: Update build to explicit valid SHA
+echo "Test 9: Update build to explicit SHA"
+KNOWN_SHA="5025a95f"
+original_sha=$(git -C build rev-parse HEAD)
+exit_code=0; output=$("$SCRIPT" build "$KNOWN_SHA" 2>&1) || exit_code=$?
+assert_exit "exits zero" 0 "$exit_code" "$output"
+actual_sha=$(git -C build rev-parse HEAD)
+if [[ "$actual_sha" == "$KNOWN_SHA"* ]]; then
+    pass "submodule HEAD matches target SHA"
+else
+    fail "submodule HEAD matches target SHA" "expected $KNOWN_SHA*, got $actual_sha"
+fi
+assert_output_contains "shows update summary" "submodule updated" "$output"
+revert_submodule build
+reverted_sha=$(git -C build rev-parse HEAD)
+if [[ "$reverted_sha" == "$original_sha" ]]; then
+    pass "reverted successfully"
+else
+    fail "reverted successfully" "SHA after revert ($reverted_sha) != original ($original_sha)"
+fi
+
+# ============================================================
+echo ""
+echo "=== Group 3: Edge Cases ==="
+echo ""
+
+# Test 10: Run from wrong directory
+echo "Test 10: Run from wrong directory"
+exit_code=0; output=$(cd /tmp && "$SCRIPT" build 2>&1) || exit_code=$?
+assert_exit "exits non-zero" 1 "$exit_code" "$output"
+assert_output_contains "error message" "no .gitmodules found" "$output"
+
+# ============================================================
+echo ""
+echo "================================"
+echo "Results: $PASS passed, $FAIL failed"
+echo "================================"
+
+# Verify submodules are clean after tests
+echo ""
+echo "Post-test submodule status:"
+git submodule status
+
+[[ $FAIL -eq 0 ]]

--- a/hack/update-upstream.sh
+++ b/hack/update-upstream.sh
@@ -1,0 +1,79 @@
+#!/bin/bash
+set -euo pipefail
+
+SUBMODULE="${1:-}"
+TARGET_SHA="${2:-}"
+
+usage() {
+    echo "Usage: $0 <submodule> <sha>"
+    echo "  <submodule>  must be 'build' or 'cli'"
+    echo "  <sha>        target commit SHA (7-40 hex characters)"
+    echo ""
+    echo "Example:"
+    echo "  $0 build abc1234def5678"
+    exit 1
+}
+
+if [[ $# -ne 2 ]]; then
+    usage
+fi
+
+if [[ "$SUBMODULE" != "build" && "$SUBMODULE" != "cli" ]]; then
+    echo "Error: submodule must be 'build' or 'cli', got '$SUBMODULE'"
+    exit 1
+fi
+
+if [[ ! -f ".gitmodules" ]]; then
+    echo "Error: must be run from the repository root (no .gitmodules found)"
+    exit 1
+fi
+
+if [[ ! "$TARGET_SHA" =~ ^[0-9a-f]{7,40}$ ]]; then
+    echo "Error: '$TARGET_SHA' is not a valid SHA (expected 7-40 hex characters)"
+    exit 1
+fi
+
+declare -A MIRROR_REPOS=(
+    [build]="redhat-openshift-builds/shipwright-io-build"
+    [cli]="redhat-openshift-builds/shipwright-io-cli"
+)
+
+REPO="${MIRROR_REPOS[$SUBMODULE]}"
+
+echo "Validating SHA against remote ${REPO}..."
+if ! gh api "repos/${REPO}/commits/${TARGET_SHA}" --silent 2>/dev/null; then
+    echo "Error: SHA '${TARGET_SHA}' not found in ${REPO}"
+    echo "Verify the SHA exists at: https://github.com/${REPO}/commit/${TARGET_SHA}"
+    exit 1
+fi
+echo "SHA validated."
+
+SUBMODULE_STATUS=$(git submodule status "$SUBMODULE" 2>/dev/null || true)
+if [[ "$SUBMODULE_STATUS" == -* ]]; then
+    echo "Submodule '$SUBMODULE' is not initialized. Initializing..."
+    git submodule update --init "$SUBMODULE"
+fi
+
+OLD_SHA=$(git -C "$SUBMODULE" rev-parse HEAD)
+echo "Current $SUBMODULE SHA: $OLD_SHA"
+
+echo "Fetching origin in $SUBMODULE..."
+git -C "$SUBMODULE" fetch origin
+
+echo "Checking out $TARGET_SHA..."
+git -C "$SUBMODULE" checkout "$TARGET_SHA"
+
+NEW_SHA=$(git -C "$SUBMODULE" rev-parse HEAD)
+
+git add "$SUBMODULE"
+
+echo ""
+echo "=== $SUBMODULE submodule updated ==="
+echo "  Old SHA: $OLD_SHA"
+echo "  New SHA: $NEW_SHA"
+echo ""
+echo "To see changelog:"
+echo "  cd $SUBMODULE && git log --oneline ${OLD_SHA}..${NEW_SHA}"
+echo ""
+echo "Staged diff:"
+git diff --cached --submodule "$SUBMODULE"

--- a/hack/update-upstream.sh
+++ b/hack/update-upstream.sh
@@ -1,0 +1,88 @@
+#!/bin/bash
+set -euo pipefail
+
+SUBMODULE="${1:-}"
+TARGET_SHA="${2:-}"
+
+usage() {
+    echo "Usage: $0 <submodule> [sha]"
+    echo "  <submodule>  must be 'build' or 'cli'"
+    echo "  <sha>        target commit SHA (7-40 hex characters)"
+    echo "               if omitted, updates to latest from tracked branch"
+    echo ""
+    echo "Examples:"
+    echo "  $0 build abc1234def5678    # explicit SHA"
+    echo "  $0 build                   # latest from tracked branch"
+    exit 1
+}
+
+if [[ $# -lt 1 || $# -gt 2 ]]; then
+    usage
+fi
+
+if [[ "$SUBMODULE" != "build" && "$SUBMODULE" != "cli" ]]; then
+    echo "Error: submodule must be 'build' or 'cli', got '$SUBMODULE'"
+    exit 1
+fi
+
+if [[ ! -f ".gitmodules" ]]; then
+    echo "Error: must be run from the repository root (no .gitmodules found)"
+    exit 1
+fi
+
+if [[ -n "$TARGET_SHA" ]] && [[ ! "$TARGET_SHA" =~ ^[0-9a-f]{7,40}$ ]]; then
+    echo "Error: '$TARGET_SHA' is not a valid SHA (expected 7-40 hex characters)"
+    exit 1
+fi
+
+case "$SUBMODULE" in
+    build) REPO="redhat-openshift-builds/shipwright-io-build" ;;
+    cli)   REPO="redhat-openshift-builds/shipwright-io-cli" ;;
+esac
+
+if [[ -n "$TARGET_SHA" ]]; then
+    echo "Validating SHA against remote ${REPO}..."
+    if ! gh api "repos/${REPO}/commits/${TARGET_SHA}" --silent 2>/dev/null; then
+        echo "Error: SHA '${TARGET_SHA}' not found in ${REPO}"
+        echo "Verify the SHA exists at: https://github.com/${REPO}/commit/${TARGET_SHA}"
+        exit 1
+    fi
+    echo "SHA validated."
+fi
+
+SUBMODULE_STATUS=$(git submodule status "$SUBMODULE" 2>/dev/null || true)
+if [[ "$SUBMODULE_STATUS" == -* ]]; then
+    echo "Submodule '$SUBMODULE' is not initialized. Initializing..."
+    git submodule update --init "$SUBMODULE"
+fi
+
+OLD_SHA=$(git -C "$SUBMODULE" rev-parse HEAD)
+echo "Current $SUBMODULE SHA: $OLD_SHA"
+
+echo "Fetching origin in $SUBMODULE..."
+git -C "$SUBMODULE" fetch origin
+
+if [[ -z "$TARGET_SHA" ]]; then
+    TRACKED_BRANCH=$(git config -f .gitmodules --get "submodule.${SUBMODULE}.branch" || echo "main")
+    echo "No SHA specified. Resolving latest from tracked branch: $TRACKED_BRANCH"
+    TARGET_SHA=$(git -C "$SUBMODULE" rev-parse "origin/$TRACKED_BRANCH")
+    echo "Resolved to: $TARGET_SHA"
+fi
+
+echo "Checking out $TARGET_SHA..."
+git -C "$SUBMODULE" checkout "$TARGET_SHA"
+
+NEW_SHA=$(git -C "$SUBMODULE" rev-parse HEAD)
+
+git add "$SUBMODULE"
+
+echo ""
+echo "=== $SUBMODULE submodule updated ==="
+echo "  Old SHA: $OLD_SHA"
+echo "  New SHA: $NEW_SHA"
+echo ""
+echo "To see changelog:"
+echo "  cd $SUBMODULE && git log --oneline ${OLD_SHA}..${NEW_SHA}"
+echo ""
+echo "Staged diff:"
+git diff --cached --submodule "$SUBMODULE"


### PR DESCRIPTION
## Summary

- Add `hack/update-upstream.sh` script for submodule SHA updates (SHA arg now optional — omit to update to latest from tracked branch)
- Add Claude skill at `.claude/skills/update-mirror/` for z-stream submodule updates on builds-X.Y branches
- Shows commit summary before updating, asks which submodules to update, creates 2 separate PRs
- Fix bash 3.2 compatibility: replace `declare -A` (associative arrays) with `case` statement — `declare -A` fails under macOS stock `/bin/bash` (3.2) with `set -u`
- Add `hack/test-update-upstream.sh` — standalone test script (no dependencies), 10 test cases, 24 assertions

## Tests

The test script (`hack/test-update-upstream.sh`) covers:

**Input validation:**
- [x] No args, too many args → usage message
- [x] Invalid submodule name → error
- [x] Invalid SHA format (too short, non-hex) → error
- [x] SHA not found in remote (hits GitHub API) → error

**Core functionality:**
- [x] Update build to latest (no SHA arg)
- [x] Update cli to latest (no SHA arg)
- [x] Update build to explicit valid SHA

**Edge cases:**
- [x] Run from wrong directory → error

All 24 assertions pass.

Co-Authored-By: Claude Opus 4.6 <noreply@anthropic.com>