### PR TITLE
chore: prepare main for 1.8 release

### DIFF
--- a/.konflux/client/Dockerfile
+++ b/.konflux/client/Dockerfile
@@ -11,7 +11,7 @@ RUN OUTPUT_DIR="/releases" VERSION="1.7.0" ./build-binary.sh
 
 LABEL \ 
     com.redhat.component="openshift-builds-client" \
-    cpe="cpe:/a:redhat:openshift_builds:1.7::el9" \
+    cpe="cpe:/a:redhat:openshift_builds:1.8::el9" \
     description="Red Hat OpenShift Builds Client" \
     distribution-scope="private" \
     io.k8s.description="Red Hat OpenShift Builds Client" \
@@ -23,6 +23,6 @@ LABEL \
     summary="Red Hat OpenShift Builds Client" \
     url="https://github.com/redhat-openshift-builds/shipwright-io" \
     vendor="Red Hat, Inc." \
-    version="v1.7.0"
+    version="v1.8.0"
 
 USER 65532:65532

--- a/.konflux/controller/Dockerfile
+++ b/.konflux/controller/Dockerfile
@@ -19,7 +19,7 @@ ENTRYPOINT ["./openshift-builds-controller"]
 
 LABEL \
     com.redhat.component="openshift-builds-controller" \
-    cpe="cpe:/a:redhat:openshift_builds:1.7::el9" \
+    cpe="cpe:/a:redhat:openshift_builds:1.8::el9" \
     description="Red Hat OpenShift Builds Controller" \
     distribution-scope="public" \
     io.k8s.description="Red Hat OpenShift Builds Controller" \
@@ -31,4 +31,4 @@ LABEL \
     summary="Red Hat OpenShift Builds Controller" \
     url="https://github.com/redhat-openshift-builds/shipwright-io" \
     vendor="Red Hat, Inc." \
-    version="v1.7.0"
+    version="v1.8.0"

--- a/.konflux/git-cloner/Dockerfile
+++ b/.konflux/git-cloner/Dockerfile
@@ -31,7 +31,7 @@ ENTRYPOINT ["/ko-app/git"]
 
 LABEL \
     com.redhat.component="openshift-builds-git-cloner" \
-    cpe="cpe:/a:redhat:openshift_builds:1.7::el9" \
+    cpe="cpe:/a:redhat:openshift_builds:1.8::el9" \
     description="Red Hat OpenShift Builds git-cloner" \
     distribution-scope="public" \
     io.k8s.description="Red Hat OpenShift Builds Git Cloner" \
@@ -43,4 +43,4 @@ LABEL \
     summary="Red Hat OpenShift Builds git Cloner" \
     url="https://github.com/redhat-openshift-builds/shipwright-io" \
     vendor="Red Hat, Inc." \
-    version="v1.7.0"
+    version="v1.8.0"

--- a/.konflux/image-bundler/Dockerfile
+++ b/.konflux/image-bundler/Dockerfile
@@ -19,7 +19,7 @@ ENTRYPOINT ["/ko-app/bundle"]
 
 LABEL \
     com.redhat.component="openshift-builds-image-bundler" \
-    cpe="cpe:/a:redhat:openshift_builds:1.7::el9" \
+    cpe="cpe:/a:redhat:openshift_builds:1.8::el9" \
     description="Red Hat OpenShift Builds Image Bundler" \
     distribution-scope="public" \
     io.k8s.description="Red Hat OpenShift Builds Image Bundler" \
@@ -31,4 +31,4 @@ LABEL \
     summary="Red Hat OpenShift Builds Image Bundler" \
     url="https://github.com/redhat-openshift-builds/shipwright-io" \
     vendor="Red Hat, Inc." \
-    version="v1.7.0"
+    version="v1.8.0"

--- a/.konflux/image-processing/Dockerfile
+++ b/.konflux/image-processing/Dockerfile
@@ -30,7 +30,7 @@ ENTRYPOINT ["/ko-app/image-processing"]
 
 LABEL \
     com.redhat.component="openshift-builds-image-processing" \
-    cpe="cpe:/a:redhat:openshift_builds:1.7::el9" \
+    cpe="cpe:/a:redhat:openshift_builds:1.8::el9" \
     description="Red Hat OpenShift Builds Image Processing" \
     distribution-scope="public" \
     io.k8s.description="Red Hat OpenShift Builds Image Processing" \
@@ -42,4 +42,4 @@ LABEL \
     summary="Red Hat OpenShift Builds Image Processing" \
     url="https://github.com/redhat-openshift-builds/shipwright-io" \
     vendor="Red Hat, Inc." \
-    version="v1.7.0"
+    version="v1.8.0"

--- a/.konflux/waiter/Dockerfile
+++ b/.konflux/waiter/Dockerfile
@@ -31,7 +31,7 @@ ENTRYPOINT ["/ko-app/waiter"]
 
 LABEL \
     com.redhat.component="openshift-builds-waiter" \
-    cpe="cpe:/a:redhat:openshift_builds:1.7::el9" \
+    cpe="cpe:/a:redhat:openshift_builds:1.8::el9" \
     description="Red Hat OpenShift Builds Waiter" \
     distribution-scope="public" \
     io.k8s.description="Red Hat OpenShift Builds Waiter" \
@@ -43,4 +43,4 @@ LABEL \
     summary="Red Hat OpenShift Builds Waiter" \
     url="https://github.com/redhat-openshift-builds/shipwright-io" \
     vendor="Red Hat, Inc." \
-    version="v1.7.0"
+    version="v1.8.0"

--- a/.konflux/webhook/Dockerfile
+++ b/.konflux/webhook/Dockerfile
@@ -19,7 +19,7 @@ ENTRYPOINT ["./openshift-builds-webhook"]
 
 LABEL \
     com.redhat.component="openshift-builds-webhook" \
-    cpe="cpe:/a:redhat:openshift_builds:1.7::el9" \
+    cpe="cpe:/a:redhat:openshift_builds:1.8::el9" \
     description="Red Hat OpenShift Builds Webhook" \
     distribution-scope="public" \
     io.k8s.description="Red Hat OpenShift Builds Webhook" \
@@ -31,4 +31,4 @@ LABEL \
     summary="Red Hat OpenShift Builds Webhook" \
     url="https://github.com/redhat-openshift-builds/shipwright-io" \
     vendor="Red Hat, Inc." \
-    version="v1.7.0"
+    version="v1.8.0"


### PR DESCRIPTION
## Summary
- Updated version labels to v1.8.0 in all .konflux/*/Dockerfile files
- Updated cpe labels to openshift_builds:1.8 in all .konflux/*/Dockerfile files

**Next step:** After merging this PR, run `/minor-builds-release-branch` to cut the release branch.

Assisted-By: Claude Code