### PR TITLE
chore: update Tekton pipelines for builds-1.8

### DIFF
--- a/.tekton/openshift-builds-client-pull-request.yaml
+++ b/.tekton/openshift-builds-client-pull-request.yaml
@@ -9,17 +9,17 @@ metadata:
     pipelinesascode.tekton.dev/max-keep-runs: "3"
     pipelinesascode.tekton.dev/on-cel-expression: |
       event == "pull_request" &&
-      target_branch == "main" &&
+      target_branch == "builds-1.8" &&
       (
         files.all.exists(x, x.matches('.tekton/openshift-builds-client-pull-request.yaml|.konflux/client')) ||
         event_title.startsWith("chore(deps): update cli digest") ||
         files.all.exists(x, x.matches('^cli/.*'))
       )
   labels:
-    appstudio.openshift.io/application: openshift-builds
-    appstudio.openshift.io/component: openshift-builds-client
+    appstudio.openshift.io/application: openshift-builds-1-8
+    appstudio.openshift.io/component: openshift-builds-client-1-8
     pipelines.appstudio.openshift.io/type: build
-  name: openshift-builds-client-on-pull-request
+  name: openshift-builds-client-1-8-on-pull-request
   namespace: rh-openshift-builds-tenant
 spec:
   params:
@@ -28,7 +28,7 @@ spec:
     - name: revision
       value: "{{revision}}"
     - name: output-image
-      value: quay.io/redhat-user-workloads/rh-openshift-builds-tenant/openshift-builds-client:on-pr-{{revision}}
+      value: quay.io/redhat-user-workloads/rh-openshift-builds-tenant/openshift-builds-client-1-8:on-pr-{{revision}}
     - name: image-expires-after
       value: 5d
     - name: dockerfile
@@ -52,7 +52,7 @@ spec:
         value: /pipelines/konflux-build-multi-platform.yaml
     resolver: git
   taskRunTemplate:
-    serviceAccountName: build-pipeline-openshift-builds-client
+    serviceAccountName: build-pipeline-openshift-builds-client-1-8
   workspaces:
     - name: git-auth
       secret:

--- a/.tekton/openshift-builds-client-push.yaml
+++ b/.tekton/openshift-builds-client-push.yaml
@@ -8,17 +8,17 @@ metadata:
     pipelinesascode.tekton.dev/max-keep-runs: "3"
     pipelinesascode.tekton.dev/on-cel-expression: |
       event == "push" &&
-      target_branch == "main" &&
+      target_branch == "builds-1.8" &&
       (
         files.all.exists(x, x.matches('.tekton/openshift-builds-client-push.yaml|.konflux/client')) ||
         event_title.startsWith("chore(deps): update cli digest") ||
         files.all.exists(x, x.matches('^cli/.*'))
       )
   labels:
-    appstudio.openshift.io/application: openshift-builds
-    appstudio.openshift.io/component: openshift-builds-client
+    appstudio.openshift.io/application: openshift-builds-1-8
+    appstudio.openshift.io/component: openshift-builds-client-1-8
     pipelines.appstudio.openshift.io/type: build
-  name: openshift-builds-client-on-push
+  name: openshift-builds-client-1-8-on-push
   namespace: rh-openshift-builds-tenant
 spec:
   params:
@@ -27,7 +27,7 @@ spec:
     - name: revision
       value: "{{revision}}"
     - name: output-image
-      value: quay.io/redhat-user-workloads/rh-openshift-builds-tenant/openshift-builds-client:{{revision}}
+      value: quay.io/redhat-user-workloads/rh-openshift-builds-tenant/openshift-builds-client-1-8:{{revision}}
     - name: dockerfile
       value: .konflux/client/Dockerfile
     - name: build-source-image
@@ -49,7 +49,7 @@ spec:
         value: /pipelines/konflux-build-multi-platform.yaml
     resolver: git
   taskRunTemplate:
-    serviceAccountName: build-pipeline-openshift-builds-client
+    serviceAccountName: build-pipeline-openshift-builds-client-1-8
   workspaces:
     - name: git-auth
       secret:

--- a/.tekton/openshift-builds-controller-pull-request.yaml
+++ b/.tekton/openshift-builds-controller-pull-request.yaml
@@ -9,17 +9,17 @@ metadata:
     pipelinesascode.tekton.dev/max-keep-runs: "3"
     pipelinesascode.tekton.dev/on-cel-expression: |
       event == "pull_request" &&
-      target_branch == "main" &&
+      target_branch == "builds-1.8" &&
       (
         files.all.exists(x, x.matches('.tekton/openshift-builds-controller-pull-request.yaml|.konflux/controller')) ||
         event_title.startsWith("chore(deps): update build digest") ||
         files.all.exists(x, x.matches('^build/.*'))
       )
   labels:
-    appstudio.openshift.io/application: openshift-builds
-    appstudio.openshift.io/component: openshift-builds-controller
+    appstudio.openshift.io/application: openshift-builds-1-8
+    appstudio.openshift.io/component: openshift-builds-controller-1-8
     pipelines.appstudio.openshift.io/type: build
-  name: openshift-builds-controller-on-pull-request
+  name: openshift-builds-controller-1-8-on-pull-request
   namespace: rh-openshift-builds-tenant
 spec:
   params:
@@ -28,7 +28,7 @@ spec:
     - name: revision
       value: "{{revision}}"
     - name: output-image
-      value: quay.io/redhat-user-workloads/rh-openshift-builds-tenant/openshift-builds-controller:on-pr-{{revision}}
+      value: quay.io/redhat-user-workloads/rh-openshift-builds-tenant/openshift-builds-controller-1-8:on-pr-{{revision}}
     - name: image-expires-after
       value: 5d
     - name: dockerfile
@@ -53,7 +53,7 @@ spec:
         value: /pipelines/konflux-build-multi-platform.yaml
     resolver: git
   taskRunTemplate:
-    serviceAccountName: build-pipeline-openshift-builds-controller
+    serviceAccountName: build-pipeline-openshift-builds-controller-1-8
   workspaces:
     - name: git-auth
       secret:

--- a/.tekton/openshift-builds-controller-push.yaml
+++ b/.tekton/openshift-builds-controller-push.yaml
@@ -8,17 +8,17 @@ metadata:
     pipelinesascode.tekton.dev/max-keep-runs: "3"
     pipelinesascode.tekton.dev/on-cel-expression: |
       event == "push" &&
-      target_branch == "main" &&
+      target_branch == "builds-1.8" &&
       (
         files.all.exists(x, x.matches('.tekton/openshift-builds-controller-push.yaml|.konflux/controller')) ||
         event_title.startsWith("chore(deps): update build digest") ||
         files.all.exists(x, x.matches('^build/.*'))
       )
   labels:
-    appstudio.openshift.io/application: openshift-builds
-    appstudio.openshift.io/component: openshift-builds-controller
+    appstudio.openshift.io/application: openshift-builds-1-8
+    appstudio.openshift.io/component: openshift-builds-controller-1-8
     pipelines.appstudio.openshift.io/type: build
-  name: openshift-builds-controller-on-push
+  name: openshift-builds-controller-1-8-on-push
   namespace: rh-openshift-builds-tenant
 spec:
   params:
@@ -27,7 +27,7 @@ spec:
     - name: revision
       value: "{{revision}}"
     - name: output-image
-      value: quay.io/redhat-user-workloads/rh-openshift-builds-tenant/openshift-builds-controller:{{revision}}
+      value: quay.io/redhat-user-workloads/rh-openshift-builds-tenant/openshift-builds-controller-1-8:{{revision}}
     - name: dockerfile
       value: .konflux/controller/Dockerfile
     - name: build-source-image
@@ -52,7 +52,7 @@ spec:
         value: /pipelines/konflux-build-multi-platform.yaml
     resolver: git
   taskRunTemplate:
-    serviceAccountName: build-pipeline-openshift-builds-controller
+    serviceAccountName: build-pipeline-openshift-builds-controller-1-8
   workspaces:
     - name: git-auth
       secret:

--- a/.tekton/openshift-builds-git-cloner-pull-request.yaml
+++ b/.tekton/openshift-builds-git-cloner-pull-request.yaml
@@ -9,7 +9,7 @@ metadata:
     pipelinesascode.tekton.dev/max-keep-runs: "3"
     pipelinesascode.tekton.dev/on-cel-expression: |
       event == "pull_request" &&
-      target_branch == "main" &&
+      target_branch == "builds-1.8" &&
       (
         files.all.exists(x, x.matches('rpms.lock.yaml')) ||
         files.all.exists(x, x.matches('.tekton/openshift-builds-git-cloner-pull-request.yaml|.konflux/git-cloner')) ||
@@ -17,10 +17,10 @@ metadata:
         files.all.exists(x, x.matches('^build/.*'))
       )
   labels:
-    appstudio.openshift.io/application: openshift-builds
-    appstudio.openshift.io/component: openshift-builds-git-cloner
+    appstudio.openshift.io/application: openshift-builds-1-8
+    appstudio.openshift.io/component: openshift-builds-git-cloner-1-8
     pipelines.appstudio.openshift.io/type: build
-  name: openshift-builds-git-cloner-on-pull-request
+  name: openshift-builds-git-cloner-1-8-on-pull-request
   namespace: rh-openshift-builds-tenant
 spec:
   params:
@@ -29,7 +29,7 @@ spec:
     - name: revision
       value: "{{revision}}"
     - name: output-image
-      value: quay.io/redhat-user-workloads/rh-openshift-builds-tenant/openshift-builds-git-cloner:on-pr-{{revision}}
+      value: quay.io/redhat-user-workloads/rh-openshift-builds-tenant/openshift-builds-git-cloner-1-8:on-pr-{{revision}}
     - name: image-expires-after
       value: 5d
     - name: dockerfile
@@ -56,7 +56,7 @@ spec:
         value: /pipelines/konflux-build-multi-platform.yaml
     resolver: git
   taskRunTemplate:
-    serviceAccountName: build-pipeline-openshift-builds-git-cloner
+    serviceAccountName: build-pipeline-openshift-builds-git-cloner-1-8
   workspaces:
     - name: git-auth
       secret:

--- a/.tekton/openshift-builds-git-cloner-push.yaml
+++ b/.tekton/openshift-builds-git-cloner-push.yaml
@@ -8,7 +8,7 @@ metadata:
     pipelinesascode.tekton.dev/max-keep-runs: "3"
     pipelinesascode.tekton.dev/on-cel-expression: |
       event == "push" &&
-      target_branch == "main" &&
+      target_branch == "builds-1.8" &&
       (
         files.all.exists(x, x.matches('rpms.lock.yaml')) ||
         files.all.exists(x, x.matches('.tekton/openshift-builds-git-cloner-push.yaml|.konflux/git-cloner')) ||
@@ -16,10 +16,10 @@ metadata:
         files.all.exists(x, x.matches('^build/.*'))
       )
   labels:
-    appstudio.openshift.io/application: openshift-builds
-    appstudio.openshift.io/component: openshift-builds-git-cloner
+    appstudio.openshift.io/application: openshift-builds-1-8
+    appstudio.openshift.io/component: openshift-builds-git-cloner-1-8
     pipelines.appstudio.openshift.io/type: build
-  name: openshift-builds-git-cloner-on-push
+  name: openshift-builds-git-cloner-1-8-on-push
   namespace: rh-openshift-builds-tenant
 spec:
   params:
@@ -28,7 +28,7 @@ spec:
     - name: revision
       value: "{{revision}}"
     - name: output-image
-      value: quay.io/redhat-user-workloads/rh-openshift-builds-tenant/openshift-builds-git-cloner:{{revision}}
+      value: quay.io/redhat-user-workloads/rh-openshift-builds-tenant/openshift-builds-git-cloner-1-8:{{revision}}
     - name: dockerfile
       value: .konflux/git-cloner/Dockerfile
     - name: build-source-image
@@ -55,7 +55,7 @@ spec:
         value: /pipelines/konflux-build-multi-platform.yaml
     resolver: git
   taskRunTemplate:
-    serviceAccountName: build-pipeline-openshift-builds-git-cloner
+    serviceAccountName: build-pipeline-openshift-builds-git-cloner-1-8
   workspaces:
     - name: git-auth
       secret:

--- a/.tekton/openshift-builds-image-bundler-pull-request.yaml
+++ b/.tekton/openshift-builds-image-bundler-pull-request.yaml
@@ -9,17 +9,17 @@ metadata:
     pipelinesascode.tekton.dev/max-keep-runs: "3"
     pipelinesascode.tekton.dev/on-cel-expression: |
       event == "pull_request" &&
-      target_branch == "main" &&
+      target_branch == "builds-1.8" &&
       (
         files.all.exists(x, x.matches('.tekton/openshift-builds-image-bundler-pull-request.yaml|.konflux/image-bundler')) ||
         event_title.startsWith("chore(deps): update build digest") ||
         files.all.exists(x, x.matches('^build/.*'))
       )
   labels:
-    appstudio.openshift.io/application: openshift-builds
-    appstudio.openshift.io/component: openshift-builds-image-bundler
+    appstudio.openshift.io/application: openshift-builds-1-8
+    appstudio.openshift.io/component: openshift-builds-image-bundler-1-8
     pipelines.appstudio.openshift.io/type: build
-  name: openshift-builds-image-bundler-on-pull-request
+  name: openshift-builds-image-bundler-1-8-on-pull-request
   namespace: rh-openshift-builds-tenant
 spec:
   params:
@@ -28,7 +28,7 @@ spec:
     - name: revision
       value: "{{revision}}"
     - name: output-image
-      value: quay.io/redhat-user-workloads/rh-openshift-builds-tenant/openshift-builds-image-bundler:on-pr-{{revision}}
+      value: quay.io/redhat-user-workloads/rh-openshift-builds-tenant/openshift-builds-image-bundler-1-8:on-pr-{{revision}}
     - name: image-expires-after
       value: 5d
     - name: dockerfile
@@ -53,7 +53,7 @@ spec:
         value: /pipelines/konflux-build-multi-platform.yaml
     resolver: git
   taskRunTemplate:
-    serviceAccountName: build-pipeline-openshift-builds-image-bundler
+    serviceAccountName: build-pipeline-openshift-builds-image-bundler-1-8
   workspaces:
     - name: git-auth
       secret:

--- a/.tekton/openshift-builds-image-bundler-push.yaml
+++ b/.tekton/openshift-builds-image-bundler-push.yaml
@@ -8,17 +8,17 @@ metadata:
     pipelinesascode.tekton.dev/max-keep-runs: "3"
     pipelinesascode.tekton.dev/on-cel-expression: |
       event == "push" &&
-      target_branch == "main" &&
+      target_branch == "builds-1.8" &&
       (
         files.all.exists(x, x.matches('.tekton/openshift-builds-image-bundler-push.yaml|.konflux/image-bundler')) ||
         event_title.startsWith("chore(deps): update build digest") ||
         files.all.exists(x, x.matches('^build/.*'))
       )
   labels:
-    appstudio.openshift.io/application: openshift-builds
-    appstudio.openshift.io/component: openshift-builds-image-bundler
+    appstudio.openshift.io/application: openshift-builds-1-8
+    appstudio.openshift.io/component: openshift-builds-image-bundler-1-8
     pipelines.appstudio.openshift.io/type: build
-  name: openshift-builds-image-bundler-on-push
+  name: openshift-builds-image-bundler-1-8-on-push
   namespace: rh-openshift-builds-tenant
 spec:
   params:
@@ -27,7 +27,7 @@ spec:
     - name: revision
       value: "{{revision}}"
     - name: output-image
-      value: quay.io/redhat-user-workloads/rh-openshift-builds-tenant/openshift-builds-image-bundler:{{revision}}
+      value: quay.io/redhat-user-workloads/rh-openshift-builds-tenant/openshift-builds-image-bundler-1-8:{{revision}}
     - name: dockerfile
       value: .konflux/image-bundler/Dockerfile
     - name: build-source-image
@@ -52,7 +52,7 @@ spec:
         value: /pipelines/konflux-build-multi-platform.yaml
     resolver: git
   taskRunTemplate:
-    serviceAccountName: build-pipeline-openshift-builds-image-bundler
+    serviceAccountName: build-pipeline-openshift-builds-image-bundler-1-8
   workspaces:
     - name: git-auth
       secret:

--- a/.tekton/openshift-builds-image-processing-pull-request.yaml
+++ b/.tekton/openshift-builds-image-processing-pull-request.yaml
@@ -9,17 +9,17 @@ metadata:
     pipelinesascode.tekton.dev/max-keep-runs: "3"
     pipelinesascode.tekton.dev/on-cel-expression: |
       event == "pull_request" &&
-      target_branch == "main" &&
+      target_branch == "builds-1.8" &&
       (
         files.all.exists(x, x.matches('.tekton/openshift-builds-image-processing-pull-request.yaml|.konflux/image-processing')) ||
         event_title.startsWith("chore(deps): update build digest") ||
         files.all.exists(x, x.matches('^build/.*'))
       )
   labels:
-    appstudio.openshift.io/application: openshift-builds
-    appstudio.openshift.io/component: openshift-builds-image-processing
+    appstudio.openshift.io/application: openshift-builds-1-8
+    appstudio.openshift.io/component: openshift-builds-image-processing-1-8
     pipelines.appstudio.openshift.io/type: build
-  name: openshift-builds-image-processing-on-pull-request
+  name: openshift-builds-image-processing-1-8-on-pull-request
   namespace: rh-openshift-builds-tenant
 spec:
   params:
@@ -28,7 +28,7 @@ spec:
     - name: revision
       value: "{{revision}}"
     - name: output-image
-      value: quay.io/redhat-user-workloads/rh-openshift-builds-tenant/openshift-builds-image-processing:on-pr-{{revision}}
+      value: quay.io/redhat-user-workloads/rh-openshift-builds-tenant/openshift-builds-image-processing-1-8:on-pr-{{revision}}
     - name: image-expires-after
       value: 5d
     - name: dockerfile
@@ -53,7 +53,7 @@ spec:
         value: /pipelines/konflux-build-multi-platform.yaml
     resolver: git
   taskRunTemplate:
-    serviceAccountName: build-pipeline-openshift-builds-image-processing
+    serviceAccountName: build-pipeline-openshift-builds-image-processing-1-8
   workspaces:
     - name: git-auth
       secret:

--- a/.tekton/openshift-builds-image-processing-push.yaml
+++ b/.tekton/openshift-builds-image-processing-push.yaml
@@ -8,17 +8,17 @@ metadata:
     pipelinesascode.tekton.dev/max-keep-runs: "3"
     pipelinesascode.tekton.dev/on-cel-expression: |
       event == "push" &&
-      target_branch == "main" &&
+      target_branch == "builds-1.8" &&
       (
         files.all.exists(x, x.matches('.tekton/openshift-builds-image-processing-push.yaml|.konflux/image-processing')) ||
         event_title.startsWith("chore(deps): update build digest") ||
         files.all.exists(x, x.matches('^build/.*'))
       )
   labels:
-    appstudio.openshift.io/application: openshift-builds
-    appstudio.openshift.io/component: openshift-builds-image-processing
+    appstudio.openshift.io/application: openshift-builds-1-8
+    appstudio.openshift.io/component: openshift-builds-image-processing-1-8
     pipelines.appstudio.openshift.io/type: build
-  name: openshift-builds-image-processing-on-push
+  name: openshift-builds-image-processing-1-8-on-push
   namespace: rh-openshift-builds-tenant
 spec:
   params:
@@ -27,7 +27,7 @@ spec:
     - name: revision
       value: "{{revision}}"
     - name: output-image
-      value: quay.io/redhat-user-workloads/rh-openshift-builds-tenant/openshift-builds-image-processing:{{revision}}
+      value: quay.io/redhat-user-workloads/rh-openshift-builds-tenant/openshift-builds-image-processing-1-8:{{revision}}
     - name: dockerfile
       value: .konflux/image-processing/Dockerfile
     - name: build-source-image
@@ -52,7 +52,7 @@ spec:
         value: /pipelines/konflux-build-multi-platform.yaml
     resolver: git
   taskRunTemplate:
-    serviceAccountName: build-pipeline-openshift-builds-image-processing
+    serviceAccountName: build-pipeline-openshift-builds-image-processing-1-8
   workspaces:
     - name: git-auth
       secret:

--- a/.tekton/openshift-builds-waiter-pull-request.yaml
+++ b/.tekton/openshift-builds-waiter-pull-request.yaml
@@ -9,7 +9,7 @@ metadata:
     pipelinesascode.tekton.dev/max-keep-runs: "3"
     pipelinesascode.tekton.dev/on-cel-expression: |
       event == "pull_request" &&
-      target_branch == "main" &&
+      target_branch == "builds-1.8" &&
       (
         files.all.exists(x, x.matches('rpms.lock.yaml')) ||
         files.all.exists(x, x.matches('.tekton/openshift-builds-waiter-pull-request.yaml|.konflux/waiter')) ||
@@ -17,10 +17,10 @@ metadata:
         files.all.exists(x, x.matches('^build/.*'))
       )
   labels:
-    appstudio.openshift.io/application: openshift-builds
-    appstudio.openshift.io/component: openshift-builds-waiter
+    appstudio.openshift.io/application: openshift-builds-1-8
+    appstudio.openshift.io/component: openshift-builds-waiter-1-8
     pipelines.appstudio.openshift.io/type: build
-  name: openshift-builds-waiter-on-pull-request
+  name: openshift-builds-waiter-1-8-on-pull-request
   namespace: rh-openshift-builds-tenant
 spec:
   params:
@@ -29,7 +29,7 @@ spec:
     - name: revision
       value: "{{revision}}"
     - name: output-image
-      value: quay.io/redhat-user-workloads/rh-openshift-builds-tenant/openshift-builds-waiter:on-pr-{{revision}}
+      value: quay.io/redhat-user-workloads/rh-openshift-builds-tenant/openshift-builds-waiter-1-8:on-pr-{{revision}}
     - name: image-expires-after
       value: 5d
     - name: dockerfile
@@ -56,7 +56,7 @@ spec:
         value: /pipelines/konflux-build-multi-platform.yaml
     resolver: git
   taskRunTemplate:
-    serviceAccountName: build-pipeline-openshift-builds-waiter
+    serviceAccountName: build-pipeline-openshift-builds-waiter-1-8
   workspaces:
     - name: git-auth
       secret:

--- a/.tekton/openshift-builds-waiter-push.yaml
+++ b/.tekton/openshift-builds-waiter-push.yaml
@@ -8,7 +8,7 @@ metadata:
     pipelinesascode.tekton.dev/max-keep-runs: "3"
     pipelinesascode.tekton.dev/on-cel-expression: |
       event == "push" &&
-      target_branch == "main" &&
+      target_branch == "builds-1.8" &&
       (
         files.all.exists(x, x.matches('rpms.lock.yaml')) ||
         files.all.exists(x, x.matches('.tekton/openshift-builds-waiter-push.yaml|.konflux/waiter')) ||
@@ -16,10 +16,10 @@ metadata:
         files.all.exists(x, x.matches('^build/.*'))
       )
   labels:
-    appstudio.openshift.io/application: openshift-builds
-    appstudio.openshift.io/component: openshift-builds-waiter
+    appstudio.openshift.io/application: openshift-builds-1-8
+    appstudio.openshift.io/component: openshift-builds-waiter-1-8
     pipelines.appstudio.openshift.io/type: build
-  name: openshift-builds-waiter-on-push
+  name: openshift-builds-waiter-1-8-on-push
   namespace: rh-openshift-builds-tenant
 spec:
   params:
@@ -28,7 +28,7 @@ spec:
     - name: revision
       value: "{{revision}}"
     - name: output-image
-      value: quay.io/redhat-user-workloads/rh-openshift-builds-tenant/openshift-builds-waiter:{{revision}}
+      value: quay.io/redhat-user-workloads/rh-openshift-builds-tenant/openshift-builds-waiter-1-8:{{revision}}
     - name: dockerfile
       value: .konflux/waiter/Dockerfile
     - name: build-source-image
@@ -55,7 +55,7 @@ spec:
         value: /pipelines/konflux-build-multi-platform.yaml
     resolver: git
   taskRunTemplate:
-    serviceAccountName: build-pipeline-openshift-builds-waiter
+    serviceAccountName: build-pipeline-openshift-builds-waiter-1-8
   workspaces:
     - name: git-auth
       secret:

--- a/.tekton/openshift-builds-webhook-pull-request.yaml
+++ b/.tekton/openshift-builds-webhook-pull-request.yaml
@@ -9,17 +9,17 @@ metadata:
     pipelinesascode.tekton.dev/max-keep-runs: "3"
     pipelinesascode.tekton.dev/on-cel-expression: |
       event == "pull_request" &&
-      target_branch == "main" &&
+      target_branch == "builds-1.8" &&
       (
         files.all.exists(x, x.matches('.tekton/openshift-builds-webhook-pull-request.yaml|.konflux/webhook')) ||
         event_title.startsWith("chore(deps): update build digest") ||
         files.all.exists(x, x.matches('^build/.*'))
       )
   labels:
-    appstudio.openshift.io/application: openshift-builds
-    appstudio.openshift.io/component: openshift-builds-webhook
+    appstudio.openshift.io/application: openshift-builds-1-8
+    appstudio.openshift.io/component: openshift-builds-webhook-1-8
     pipelines.appstudio.openshift.io/type: build
-  name: openshift-builds-webhook-on-pull-request
+  name: openshift-builds-webhook-1-8-on-pull-request
   namespace: rh-openshift-builds-tenant
 spec:
   params:
@@ -28,7 +28,7 @@ spec:
     - name: revision
       value: "{{revision}}"
     - name: output-image
-      value: quay.io/redhat-user-workloads/rh-openshift-builds-tenant/openshift-builds-webhook:on-pr-{{revision}}
+      value: quay.io/redhat-user-workloads/rh-openshift-builds-tenant/openshift-builds-webhook-1-8:on-pr-{{revision}}
     - name: image-expires-after
       value: 5d
     - name: dockerfile
@@ -53,7 +53,7 @@ spec:
         value: /pipelines/konflux-build-multi-platform.yaml
     resolver: git
   taskRunTemplate:
-    serviceAccountName: build-pipeline-openshift-builds-webhook
+    serviceAccountName: build-pipeline-openshift-builds-webhook-1-8
   workspaces:
     - name: git-auth
       secret:

--- a/.tekton/openshift-builds-webhook-push.yaml
+++ b/.tekton/openshift-builds-webhook-push.yaml
@@ -8,17 +8,17 @@ metadata:
     pipelinesascode.tekton.dev/max-keep-runs: "3"
     pipelinesascode.tekton.dev/on-cel-expression: |
       event == "push" &&
-      target_branch == "main" &&
+      target_branch == "builds-1.8" &&
       (
         files.all.exists(x, x.matches('.tekton/openshift-builds-webhook-push.yaml|.konflux/webhook')) ||
         event_title.startsWith("chore(deps): update build digest") ||
         files.all.exists(x, x.matches('^build/.*'))
       )
   labels:
-    appstudio.openshift.io/application: openshift-builds
-    appstudio.openshift.io/component: openshift-builds-webhook
+    appstudio.openshift.io/application: openshift-builds-1-8
+    appstudio.openshift.io/component: openshift-builds-webhook-1-8
     pipelines.appstudio.openshift.io/type: build
-  name: openshift-builds-webhook-on-push
+  name: openshift-builds-webhook-1-8-on-push
   namespace: rh-openshift-builds-tenant
 spec:
   params:
@@ -27,7 +27,7 @@ spec:
     - name: revision
       value: "{{revision}}"
     - name: output-image
-      value: quay.io/redhat-user-workloads/rh-openshift-builds-tenant/openshift-builds-webhook:{{revision}}
+      value: quay.io/redhat-user-workloads/rh-openshift-builds-tenant/openshift-builds-webhook-1-8:{{revision}}
     - name: dockerfile
       value: .konflux/webhook/Dockerfile
     - name: build-source-image
@@ -52,7 +52,7 @@ spec:
         value: /pipelines/konflux-build-multi-platform.yaml
     resolver: git
   taskRunTemplate:
-    serviceAccountName: build-pipeline-openshift-builds-webhook
+    serviceAccountName: build-pipeline-openshift-builds-webhook-1-8
   workspaces:
     - name: git-auth
       secret:


### PR DESCRIPTION
## Summary
- Updated target_branch to builds-1.8 in all 14 pipeline files
- Updated application and component names with -1-8 suffix
- Updated image URLs and service accounts for 1.8

Assisted-By: Claude Code