### PR TITLE
chore: update client version and pipeline max-keep-runs for builds-1.8

### DIFF
--- a/.konflux/client/Dockerfile
+++ b/.konflux/client/Dockerfile
@@ -7,7 +7,7 @@ USER 0
 COPY hack/build-binary.sh build-binary.sh
 COPY cli cli
 
-RUN OUTPUT_DIR="/releases" VERSION="1.7.0" ./build-binary.sh
+RUN OUTPUT_DIR="/releases" VERSION="1.8.0" ./build-binary.sh
 
 LABEL \ 
     com.redhat.component="openshift-builds-client" \

--- a/.tekton/openshift-builds-client-pull-request.yaml
+++ b/.tekton/openshift-builds-client-pull-request.yaml
@@ -6,7 +6,7 @@ metadata:
     build.appstudio.redhat.com/commit_sha: "{{revision}}"
     build.appstudio.redhat.com/pull_request_number: "{{pull_request_number}}"
     build.appstudio.redhat.com/target_branch: "{{target_branch}}"
-    pipelinesascode.tekton.dev/max-keep-runs: "3"
+    pipelinesascode.tekton.dev/max-keep-runs: "4"
     pipelinesascode.tekton.dev/on-cel-expression: |
       event == "pull_request" &&
       target_branch == "builds-1.8" &&

--- a/.tekton/openshift-builds-client-push.yaml
+++ b/.tekton/openshift-builds-client-push.yaml
@@ -5,7 +5,7 @@ metadata:
     build.appstudio.openshift.io/repo: https://github.com/redhat-openshift-builds/shipwright-io?rev={{revision}}
     build.appstudio.redhat.com/commit_sha: "{{revision}}"
     build.appstudio.redhat.com/target_branch: "{{target_branch}}"
-    pipelinesascode.tekton.dev/max-keep-runs: "3"
+    pipelinesascode.tekton.dev/max-keep-runs: "4"
     pipelinesascode.tekton.dev/on-cel-expression: |
       event == "push" &&
       target_branch == "builds-1.8" &&

--- a/.tekton/openshift-builds-controller-pull-request.yaml
+++ b/.tekton/openshift-builds-controller-pull-request.yaml
@@ -6,7 +6,7 @@ metadata:
     build.appstudio.redhat.com/commit_sha: "{{revision}}"
     build.appstudio.redhat.com/pull_request_number: "{{pull_request_number}}"
     build.appstudio.redhat.com/target_branch: "{{target_branch}}"
-    pipelinesascode.tekton.dev/max-keep-runs: "3"
+    pipelinesascode.tekton.dev/max-keep-runs: "4"
     pipelinesascode.tekton.dev/on-cel-expression: |
       event == "pull_request" &&
       target_branch == "builds-1.8" &&

--- a/.tekton/openshift-builds-controller-push.yaml
+++ b/.tekton/openshift-builds-controller-push.yaml
@@ -5,7 +5,7 @@ metadata:
     build.appstudio.openshift.io/repo: https://github.com/redhat-openshift-builds/shipwright-io?rev={{revision}}
     build.appstudio.redhat.com/commit_sha: "{{revision}}"
     build.appstudio.redhat.com/target_branch: "{{target_branch}}"
-    pipelinesascode.tekton.dev/max-keep-runs: "3"
+    pipelinesascode.tekton.dev/max-keep-runs: "4"
     pipelinesascode.tekton.dev/on-cel-expression: |
       event == "push" &&
       target_branch == "builds-1.8" &&

--- a/.tekton/openshift-builds-git-cloner-pull-request.yaml
+++ b/.tekton/openshift-builds-git-cloner-pull-request.yaml
@@ -6,7 +6,7 @@ metadata:
     build.appstudio.redhat.com/commit_sha: "{{revision}}"
     build.appstudio.redhat.com/pull_request_number: "{{pull_request_number}}"
     build.appstudio.redhat.com/target_branch: "{{target_branch}}"
-    pipelinesascode.tekton.dev/max-keep-runs: "3"
+    pipelinesascode.tekton.dev/max-keep-runs: "4"
     pipelinesascode.tekton.dev/on-cel-expression: |
       event == "pull_request" &&
       target_branch == "builds-1.8" &&

--- a/.tekton/openshift-builds-git-cloner-push.yaml
+++ b/.tekton/openshift-builds-git-cloner-push.yaml
@@ -5,7 +5,7 @@ metadata:
     build.appstudio.openshift.io/repo: https://github.com/redhat-openshift-builds/shipwright-io?rev={{revision}}
     build.appstudio.redhat.com/commit_sha: "{{revision}}"
     build.appstudio.redhat.com/target_branch: "{{target_branch}}"
-    pipelinesascode.tekton.dev/max-keep-runs: "3"
+    pipelinesascode.tekton.dev/max-keep-runs: "4"
     pipelinesascode.tekton.dev/on-cel-expression: |
       event == "push" &&
       target_branch == "builds-1.8" &&

--- a/.tekton/openshift-builds-image-bundler-pull-request.yaml
+++ b/.tekton/openshift-builds-image-bundler-pull-request.yaml
@@ -6,7 +6,7 @@ metadata:
     build.appstudio.redhat.com/commit_sha: "{{revision}}"
     build.appstudio.redhat.com/pull_request_number: "{{pull_request_number}}"
     build.appstudio.redhat.com/target_branch: "{{target_branch}}"
-    pipelinesascode.tekton.dev/max-keep-runs: "3"
+    pipelinesascode.tekton.dev/max-keep-runs: "4"
     pipelinesascode.tekton.dev/on-cel-expression: |
       event == "pull_request" &&
       target_branch == "builds-1.8" &&

--- a/.tekton/openshift-builds-image-bundler-push.yaml
+++ b/.tekton/openshift-builds-image-bundler-push.yaml
@@ -5,7 +5,7 @@ metadata:
     build.appstudio.openshift.io/repo: https://github.com/redhat-openshift-builds/shipwright-io?rev={{revision}}
     build.appstudio.redhat.com/commit_sha: "{{revision}}"
     build.appstudio.redhat.com/target_branch: "{{target_branch}}"
-    pipelinesascode.tekton.dev/max-keep-runs: "3"
+    pipelinesascode.tekton.dev/max-keep-runs: "4"
     pipelinesascode.tekton.dev/on-cel-expression: |
       event == "push" &&
       target_branch == "builds-1.8" &&

--- a/.tekton/openshift-builds-image-processing-pull-request.yaml
+++ b/.tekton/openshift-builds-image-processing-pull-request.yaml
@@ -6,7 +6,7 @@ metadata:
     build.appstudio.redhat.com/commit_sha: "{{revision}}"
     build.appstudio.redhat.com/pull_request_number: "{{pull_request_number}}"
     build.appstudio.redhat.com/target_branch: "{{target_branch}}"
-    pipelinesascode.tekton.dev/max-keep-runs: "3"
+    pipelinesascode.tekton.dev/max-keep-runs: "4"
     pipelinesascode.tekton.dev/on-cel-expression: |
       event == "pull_request" &&
       target_branch == "builds-1.8" &&

--- a/.tekton/openshift-builds-image-processing-push.yaml
+++ b/.tekton/openshift-builds-image-processing-push.yaml
@@ -5,7 +5,7 @@ metadata:
     build.appstudio.openshift.io/repo: https://github.com/redhat-openshift-builds/shipwright-io?rev={{revision}}
     build.appstudio.redhat.com/commit_sha: "{{revision}}"
     build.appstudio.redhat.com/target_branch: "{{target_branch}}"
-    pipelinesascode.tekton.dev/max-keep-runs: "3"
+    pipelinesascode.tekton.dev/max-keep-runs: "4"
     pipelinesascode.tekton.dev/on-cel-expression: |
       event == "push" &&
       target_branch == "builds-1.8" &&

--- a/.tekton/openshift-builds-waiter-pull-request.yaml
+++ b/.tekton/openshift-builds-waiter-pull-request.yaml
@@ -6,7 +6,7 @@ metadata:
     build.appstudio.redhat.com/commit_sha: "{{revision}}"
     build.appstudio.redhat.com/pull_request_number: "{{pull_request_number}}"
     build.appstudio.redhat.com/target_branch: "{{target_branch}}"
-    pipelinesascode.tekton.dev/max-keep-runs: "3"
+    pipelinesascode.tekton.dev/max-keep-runs: "4"
     pipelinesascode.tekton.dev/on-cel-expression: |
       event == "pull_request" &&
       target_branch == "builds-1.8" &&

--- a/.tekton/openshift-builds-waiter-push.yaml
+++ b/.tekton/openshift-builds-waiter-push.yaml
@@ -5,7 +5,7 @@ metadata:
     build.appstudio.openshift.io/repo: https://github.com/redhat-openshift-builds/shipwright-io?rev={{revision}}
     build.appstudio.redhat.com/commit_sha: "{{revision}}"
     build.appstudio.redhat.com/target_branch: "{{target_branch}}"
-    pipelinesascode.tekton.dev/max-keep-runs: "3"
+    pipelinesascode.tekton.dev/max-keep-runs: "4"
     pipelinesascode.tekton.dev/on-cel-expression: |
       event == "push" &&
       target_branch == "builds-1.8" &&

--- a/.tekton/openshift-builds-webhook-pull-request.yaml
+++ b/.tekton/openshift-builds-webhook-pull-request.yaml
@@ -6,7 +6,7 @@ metadata:
     build.appstudio.redhat.com/commit_sha: "{{revision}}"
     build.appstudio.redhat.com/pull_request_number: "{{pull_request_number}}"
     build.appstudio.redhat.com/target_branch: "{{target_branch}}"
-    pipelinesascode.tekton.dev/max-keep-runs: "3"
+    pipelinesascode.tekton.dev/max-keep-runs: "4"
     pipelinesascode.tekton.dev/on-cel-expression: |
       event == "pull_request" &&
       target_branch == "builds-1.8" &&

--- a/.tekton/openshift-builds-webhook-push.yaml
+++ b/.tekton/openshift-builds-webhook-push.yaml
@@ -5,7 +5,7 @@ metadata:
     build.appstudio.openshift.io/repo: https://github.com/redhat-openshift-builds/shipwright-io?rev={{revision}}
     build.appstudio.redhat.com/commit_sha: "{{revision}}"
     build.appstudio.redhat.com/target_branch: "{{target_branch}}"
-    pipelinesascode.tekton.dev/max-keep-runs: "3"
+    pipelinesascode.tekton.dev/max-keep-runs: "4"
     pipelinesascode.tekton.dev/on-cel-expression: |
       event == "push" &&
       target_branch == "builds-1.8" &&


### PR DESCRIPTION
## Summary

- Update client binary VERSION from 1.7.0 to 1.8.0 in .konflux/client/Dockerfile
- Bump pipelinesascode max-keep-runs from 3 to 4 across all 14 .tekton pipeline YAMLs

🤖 Generated with [Claude Code](https://claude.com/claude-code)