### PR TITLE
chore: update submodules to point to builds-1.7 branch

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -4,5 +4,5 @@
 	branch = release-v0.18
 [submodule "build"]
 	path = build
-	url = https://github.com/shipwright-io/build.git
-	branch = release-v0.18
+	url = https://github.com/redhat-openshift-builds/shipwright-io-build.git
+	branch = builds-1.7


### PR DESCRIPTION
Edit .gitmodules to change the build submodule URL from shipwright-io/build.git to redhat-openshift-builds/shipwright-io-build.git and branch from release-v0.18 to builds-1.7