### PR TITLE
fix: ignore build and cli path from symlink check

### DIFF
--- a/.tekton/openshift-builds-client-pull-request.yaml
+++ b/.tekton/openshift-builds-client-pull-request.yaml
@@ -42,6 +42,8 @@ spec:
         - linux/x86_64
     - name: prefetch-input
       value: '{"packages": [{"type": "gomod", "path": "build"}]}'
+    - name: enableSymlinkCheck
+      value: "false"
   pipelineRef:
     params:
       - name: url

--- a/.tekton/openshift-builds-client-push.yaml
+++ b/.tekton/openshift-builds-client-push.yaml
@@ -39,6 +39,8 @@ spec:
         - linux/x86_64
     - name: prefetch-input
       value: '{"packages": [{"type": "gomod", "path": "build"}]}'
+    - name: enableSymlinkCheck
+      value: "false"
   pipelineRef:
     params:
       - name: url

--- a/.tekton/openshift-builds-controller-pull-request.yaml
+++ b/.tekton/openshift-builds-controller-pull-request.yaml
@@ -43,6 +43,8 @@ spec:
         - linux/arm64
     - name: prefetch-input
       value: '{"packages": [{"type": "gomod", "path": "build"}]}'
+    - name: enableSymlinkCheck
+      value: "false"
   pipelineRef:
     params:
       - name: url

--- a/.tekton/openshift-builds-controller-push.yaml
+++ b/.tekton/openshift-builds-controller-push.yaml
@@ -42,6 +42,8 @@ spec:
         - linux/s390x
     - name: prefetch-input
       value: '{"packages": [{"type": "gomod", "path": "build"}]}'
+    - name: enableSymlinkCheck
+      value: "false"
   pipelineRef:
     params:
       - name: url

--- a/.tekton/openshift-builds-git-cloner-pull-request.yaml
+++ b/.tekton/openshift-builds-git-cloner-pull-request.yaml
@@ -46,6 +46,8 @@ spec:
         - linux/arm64
     - name: prefetch-input
       value: '{"packages": [{"type": "gomod", "path": "build"},{"type": "rpm"}]}'
+    - name: enableSymlinkCheck
+      value: "false"
   pipelineRef:
     params:
       - name: url

--- a/.tekton/openshift-builds-git-cloner-push.yaml
+++ b/.tekton/openshift-builds-git-cloner-push.yaml
@@ -45,6 +45,8 @@ spec:
         - linux/s390x
     - name: prefetch-input
       value: '{"packages": [{"type": "gomod", "path": "build"},{"type": "rpm"}]}'
+    - name: enableSymlinkCheck
+      value: "false"
   pipelineRef:
     params:
       - name: url

--- a/.tekton/openshift-builds-image-bundler-pull-request.yaml
+++ b/.tekton/openshift-builds-image-bundler-pull-request.yaml
@@ -43,6 +43,8 @@ spec:
         - linux/arm64
     - name: prefetch-input
       value: '{"packages": [{"type": "gomod", "path": "build"}]}'
+    - name: enableSymlinkCheck
+      value: "false"
   pipelineRef:
     params:
       - name: url

--- a/.tekton/openshift-builds-image-bundler-push.yaml
+++ b/.tekton/openshift-builds-image-bundler-push.yaml
@@ -42,6 +42,8 @@ spec:
         - linux/s390x
     - name: prefetch-input
       value: '{"packages": [{"type": "gomod", "path": "build"}]}'
+    - name: enableSymlinkCheck
+      value: "false"
   pipelineRef:
     params:
       - name: url

--- a/.tekton/openshift-builds-image-processing-pull-request.yaml
+++ b/.tekton/openshift-builds-image-processing-pull-request.yaml
@@ -43,6 +43,8 @@ spec:
         - linux/arm64
     - name: prefetch-input
       value: '{"packages": [{"type": "gomod", "path": "build"}]}'
+    - name: enableSymlinkCheck
+      value: "false"
   pipelineRef:
     params:
       - name: url

--- a/.tekton/openshift-builds-image-processing-push.yaml
+++ b/.tekton/openshift-builds-image-processing-push.yaml
@@ -42,6 +42,8 @@ spec:
         - linux/s390x
     - name: prefetch-input
       value: '{"packages": [{"type": "gomod", "path": "build"}]}'
+    - name: enableSymlinkCheck
+      value: "false"
   pipelineRef:
     params:
       - name: url

--- a/.tekton/openshift-builds-waiter-pull-request.yaml
+++ b/.tekton/openshift-builds-waiter-pull-request.yaml
@@ -46,6 +46,8 @@ spec:
         - linux/arm64
     - name: prefetch-input
       value: '{"packages": [{"type": "gomod", "path": "build"},{"type": "rpm"}]}'
+    - name: enableSymlinkCheck
+      value: "false"
   pipelineRef:
     params:
       - name: url

--- a/.tekton/openshift-builds-waiter-push.yaml
+++ b/.tekton/openshift-builds-waiter-push.yaml
@@ -45,6 +45,8 @@ spec:
         - linux/s390x
     - name: prefetch-input
       value: '{"packages": [{"type": "gomod", "path": "build"},{"type": "rpm"}]}'
+    - name: enableSymlinkCheck
+      value: "false"
   pipelineRef:
     params:
       - name: url

--- a/.tekton/openshift-builds-webhook-pull-request.yaml
+++ b/.tekton/openshift-builds-webhook-pull-request.yaml
@@ -43,6 +43,8 @@ spec:
         - linux/arm64
     - name: prefetch-input
       value: '{"packages": [{"type": "gomod", "path": "build"}]}'
+    - name: enableSymlinkCheck
+      value: "false"
   pipelineRef:
     params:
       - name: url

--- a/.tekton/openshift-builds-webhook-push.yaml
+++ b/.tekton/openshift-builds-webhook-push.yaml
@@ -42,6 +42,8 @@ spec:
         - linux/s390x
     - name: prefetch-input
       value: '{"packages": [{"type": "gomod", "path": "build"}]}'
+    - name: enableSymlinkCheck
+      value: "false"
   pipelineRef:
     params:
       - name: url


### PR DESCRIPTION
- ignore build and cli paths because they are submodules

Signed-off-by: Avinal Kumar <avinal@redhat.com>
